### PR TITLE
Center tower viewport and clarify vault flips

### DIFF
--- a/assets/css/base/base.css
+++ b/assets/css/base/base.css
@@ -1,0 +1,90 @@
+* {
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+  -webkit-tap-highlight-color: transparent;
+}
+html {
+  scroll-behavior: smooth;
+  overflow-x: hidden;
+}
+body {
+  font-family: Montserrat, sans-serif;
+  background: #000;
+  color: var(--white);
+  overflow-x: hidden;
+  cursor: none;
+  -webkit-font-smoothing: antialiased;
+}
+
+.button-glow {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  padding: 0.85rem 1.8rem;
+  border-radius: 6px;
+  background: linear-gradient(135deg, var(--orange), var(--gold));
+  color: #0b101a;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.78rem;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease, filter 0.3s ease;
+  overflow: hidden;
+  box-shadow:
+    0 10px 24px rgba(255, 107, 53, 0.38),
+    0 0 18px rgba(255, 215, 0, 0.3);
+}
+
+.button-glow::before {
+  content: "";
+  position: absolute;
+  inset: -20%;
+  background: linear-gradient(135deg, var(--orange), var(--gold));
+  filter: blur(18px);
+  opacity: 0.6;
+  z-index: -1;
+  transition: opacity 0.4s ease, transform 0.4s ease;
+  animation: buttonGlowPulse 3s ease-in-out infinite;
+}
+
+.button-glow:hover,
+.button-glow:focus-visible {
+  transform: translateY(-2px);
+  box-shadow:
+    0 16px 32px rgba(255, 107, 53, 0.55),
+    0 0 28px rgba(255, 215, 0, 0.4);
+}
+
+.button-glow:hover::before,
+.button-glow:focus-visible::before {
+  opacity: 1;
+  transform: scale(1.05);
+}
+
+.button-glow:focus-visible {
+  outline: 2px solid rgba(255, 215, 0, 0.65);
+  outline-offset: 4px;
+}
+
+@keyframes buttonGlowPulse {
+  0%,
+  100% {
+    opacity: 0.55;
+    transform: scale(1);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.06);
+  }
+}
+@media (max-width: 1024px) {
+  body {
+    cursor: auto;
+  }
+}

--- a/assets/css/base/variables.css
+++ b/assets/css/base/variables.css
@@ -1,0 +1,14 @@
+:root {
+  --black: #0a0e14;
+  --dark-teal: #0d1b2a;
+  --gold: #d4af37;
+  --gold-light: #ffd700;
+  --gold-dark: #9a7c1f;
+  --amber: #ffbf00;
+  --orange: #ff6b35;
+  --teal: #4a9b8e;
+  --cyan: #64dfdf;
+  --white: #e8eaed;
+  --white-dim: #94a3b8;
+  --left: clamp(24px, 8vw, 120px);
+}

--- a/assets/css/components/background.css
+++ b/assets/css/components/background.css
@@ -1,0 +1,40 @@
+.carbon-fiber {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+  opacity: 0.12;
+  background-image:
+    repeating-linear-gradient(
+      0deg,
+      transparent,
+      transparent 2px,
+      rgba(74, 155, 142, 0.2) 2px,
+      rgba(74, 155, 142, 0.2) 4px
+    ),
+    repeating-linear-gradient(
+      90deg,
+      transparent,
+      transparent 2px,
+      rgba(255, 107, 53, 0.12) 2px,
+      rgba(255, 107, 53, 0.12) 4px
+    );
+  background-size: 6px 6px;
+  pointer-events: none;
+}
+.vignette {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 3;
+  background: radial-gradient(
+    ellipse at center,
+    transparent 15%,
+    rgba(10, 14, 20, 0.85) 85%
+  );
+}

--- a/assets/css/components/cards.css
+++ b/assets/css/components/cards.css
@@ -1,0 +1,539 @@
+/* Slider containers */
+.slider-container {
+  position: relative;
+  margin-top: 3rem;
+  padding: 3rem 1.5rem 1.5rem 2.2rem;
+  overflow: visible;
+}
+
+.slider-wrapper {
+  display: flex;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  overflow-x: auto;
+  overflow-y: visible;
+  scroll-snap-type: x mandatory;
+  scroll-behavior: smooth;
+  padding: 1.5rem 0 0.5rem 0.5rem;
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.slider-wrapper::-webkit-scrollbar {
+  display: none;
+}
+
+.slider-wrapper > * {
+  scroll-snap-align: center;
+}
+
+.carousel-nav {
+  position: absolute;
+  inset: auto clamp(0.5rem, 2vw, 1.5rem) clamp(-2rem, -1vw, -1.5rem) clamp(0.5rem, 2vw, 1.5rem);
+  display: flex;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.carousel-arrow {
+  pointer-events: auto;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--gold);
+  background: rgba(13, 27, 42, 0.75);
+  cursor: pointer;
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.45);
+}
+
+.carousel-arrow:hover {
+  transform: translateY(-4px);
+  box-shadow:
+    0 12px 35px rgba(0, 0, 0, 0.6),
+    0 0 18px rgba(255, 215, 0, 0.35);
+}
+
+/* Overlay */
+#cardOverlay.card-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 8, 14, 0.55);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease, visibility 0.35s ease;
+  z-index: 900;
+}
+
+#cardOverlay.card-overlay.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+body.card-open,
+html.card-open {
+  overflow: hidden;
+}
+
+/* Vault card base */
+.vault-card {
+  position: relative;
+  flex: 0 0 clamp(260px, 24vw, 320px);
+  height: clamp(360px, 50vh, 420px);
+  margin-block-start: 2.4rem;
+  margin-inline-start: 1.6rem;
+  perspective: 1800px;
+  transform-style: preserve-3d;
+  transition:
+    transform 0.45s ease,
+    box-shadow 0.45s ease,
+    filter 0.45s ease,
+    opacity 0.3s ease;
+  border-radius: 18px;
+  transform-origin: center;
+  overflow: visible;
+  background: transparent;
+  will-change: transform;
+}
+
+.vault-card:not(.is-active):hover,
+.vault-card.is-hovered:not(.is-active) {
+  transform: scale(1.04);
+  box-shadow:
+    0 32px 70px rgba(0, 0, 0, 0.55),
+    0 0 28px rgba(255, 215, 0, 0.25);
+}
+
+.vault-card.is-muted {
+  opacity: 0.75;
+  filter: saturate(0.92) brightness(0.92);
+  transform: scale(0.97);
+}
+
+.vault-card-inner {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  transform-style: preserve-3d;
+  transform: rotateY(0deg);
+  transition: transform 0.65s cubic-bezier(0.19, 1, 0.22, 1);
+  will-change: transform;
+}
+
+.vault-face {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  padding: clamp(1.8rem, 3vw, 2.4rem);
+  border-radius: 18px;
+  backface-visibility: hidden;
+  overflow: hidden;
+  background: radial-gradient(circle at 18% 22%, rgba(255, 215, 0, 0.18), transparent 55%),
+    linear-gradient(155deg, rgba(17, 30, 46, 0.95), rgba(5, 12, 20, 0.9));
+  border: 1px solid rgba(212, 175, 55, 0.25);
+  box-shadow:
+    inset 0 0 22px rgba(255, 215, 0, 0.08),
+    0 24px 46px rgba(0, 0, 0, 0.55);
+}
+
+.vault-face.vault-locked {
+  z-index: 2;
+}
+
+.vault-face.vault-content {
+  transform: rotateY(180deg);
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 1.2rem;
+  text-align: left;
+  background: radial-gradient(circle at 78% 12%, rgba(255, 200, 120, 0.18), transparent 60%),
+    linear-gradient(170deg, rgba(12, 24, 38, 0.98), rgba(28, 48, 70, 0.95));
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.4s ease;
+}
+
+.vault-lock {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 4.2rem;
+  height: 4.2rem;
+  margin-bottom: 1.4rem;
+  color: var(--gold);
+  text-shadow: 0 0 18px rgba(255, 215, 0, 0.45);
+}
+
+.lock-icon,
+.vault-unlocked-icon {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 2.5rem;
+  transition: transform 0.45s ease, opacity 0.45s ease;
+  line-height: 1;
+}
+
+.vault-unlocked-icon {
+  opacity: 0;
+  transform: scale(0.4) rotate(-18deg);
+}
+
+.vault-card.is-unlocked .lock-icon {
+  transform: translateY(-18px);
+  opacity: 0;
+}
+
+.vault-card.is-unlocked .vault-unlocked-icon {
+  opacity: 1;
+  transform: scale(1) rotate(0deg);
+}
+
+.vault-title {
+  font-size: clamp(1.2rem, 2.4vw, 1.5rem);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--white);
+  margin-bottom: 0.75rem;
+  text-align: center;
+}
+
+.vault-subtitle {
+  font-size: 0.95rem;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.7);
+  text-transform: uppercase;
+  margin-bottom: 0.5rem;
+  text-align: center;
+}
+
+.vault-prompt {
+  font-size: 0.85rem;
+  letter-spacing: 0.28em;
+  color: rgba(212, 175, 55, 0.85);
+  text-transform: uppercase;
+  text-align: center;
+}
+
+.vault-content h3 {
+  font-size: clamp(1.4rem, 2.5vw, 1.8rem);
+  margin: 0;
+  color: var(--white);
+  letter-spacing: 0.02em;
+}
+
+.vault-content p {
+  color: rgba(232, 234, 237, 0.88);
+  line-height: 1.7;
+  margin: 0;
+}
+
+.vault-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1.6rem;
+  margin-top: auto;
+  border-radius: 999px;
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  text-decoration: none;
+  transition: background 0.3s ease, color 0.3s ease, border-color 0.3s ease;
+}
+
+.vault-link:hover {
+  background: rgba(212, 175, 55, 0.18);
+  color: #fff;
+  border-color: rgba(255, 215, 0, 0.6);
+}
+
+.vault-close {
+  align-self: flex-end;
+  border: none;
+  background: rgba(13, 27, 42, 0.65);
+  color: rgba(255, 255, 255, 0.85);
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  font-size: 1.1rem;
+  cursor: pointer;
+  transition: transform 0.3s ease, background 0.3s ease;
+}
+
+.vault-close:hover {
+  transform: rotate(90deg);
+  background: rgba(255, 215, 0, 0.3);
+}
+
+.vault-icon-display {
+  font-size: clamp(2.6rem, 4vw, 3.4rem);
+  color: rgba(255, 215, 0, 0.85);
+  text-shadow:
+    0 0 15px rgba(255, 215, 0, 0.5),
+    0 0 35px rgba(255, 140, 0, 0.3);
+}
+
+.vault-card.is-active {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  width: min(92vw, 680px);
+  height: min(90vh, 780px);
+  transform: translate(-50%, -50%) scale(1.08);
+  z-index: 1200;
+  flex: 0 0 auto;
+  box-shadow:
+    0 42px 120px rgba(0, 0, 0, 0.65),
+    0 0 52px rgba(255, 215, 0, 0.36);
+  border-radius: 22px;
+  overflow: hidden;
+  perspective: 2200px;
+}
+
+.vault-card.is-active .vault-card-inner {
+  height: 100%;
+  transform: rotateY(180deg);
+}
+
+.vault-card.is-active .vault-face.vault-locked {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.vault-card.is-active .vault-face.vault-content {
+  opacity: 1;
+  filter: none;
+  pointer-events: auto;
+  overflow-y: auto;
+  padding: clamp(2rem, 3vw, 2.6rem);
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+  overscroll-behavior: contain;
+}
+
+.vault-card.is-active .vault-face.vault-content::-webkit-scrollbar {
+  display: none;
+}
+
+/* Team cards */
+.team-card .vault-face.vault-content {
+  gap: 1.4rem;
+}
+
+.team-photo-full {
+  width: 100%;
+  height: clamp(220px, 35vh, 320px);
+  object-fit: cover;
+  border-radius: 14px;
+  box-shadow:
+    0 18px 45px rgba(0, 0, 0, 0.45),
+    0 0 18px rgba(74, 155, 142, 0.25);
+}
+
+.team-details {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.team-details .team-role {
+  font-size: 0.95rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.team-social {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.8rem;
+}
+
+.team-social a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.1rem;
+  border-radius: 999px;
+  background: rgba(13, 27, 42, 0.8);
+  border: 1px solid rgba(74, 155, 142, 0.35);
+  color: rgba(232, 234, 237, 0.85);
+  font-size: 0.75rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: none;
+  transition: background 0.3s ease, color 0.3s ease;
+}
+
+.team-social a:hover {
+  background: rgba(74, 155, 142, 0.4);
+  color: #fff;
+}
+
+.team-join {
+  margin: 3rem auto 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* Testimonials */
+.testimonials-slider .testimonial-card {
+  flex: 0 0 clamp(260px, 24vw, 320px);
+  min-height: clamp(320px, 45vh, 360px);
+  background: linear-gradient(150deg, rgba(7, 12, 20, 0.95), rgba(12, 24, 36, 0.92));
+  border: 1px solid rgba(74, 155, 142, 0.25);
+  border-radius: 18px;
+  padding: clamp(1.6rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow:
+    0 25px 50px rgba(0, 0, 0, 0.5),
+    0 0 20px rgba(255, 215, 0, 0.12);
+}
+
+.testimonial-photo {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  object-fit: cover;
+  border: 2px solid rgba(212, 175, 55, 0.45);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.4);
+}
+
+.testimonial-card blockquote {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.7;
+  color: rgba(232, 234, 237, 0.88);
+  font-style: italic;
+}
+
+.testimonial-name {
+  font-weight: 700;
+  color: var(--white);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.85rem;
+}
+
+.testimonial-meta {
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  color: rgba(255, 255, 255, 0.55);
+  text-transform: uppercase;
+}
+
+/* Blog cards */
+.blog-card {
+  flex: 0 0 clamp(260px, 26vw, 340px);
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(7, 12, 20, 0.9), rgba(7, 14, 22, 0.95));
+  border-radius: 18px;
+  overflow: hidden;
+  border: 1px solid rgba(212, 175, 55, 0.18);
+  box-shadow:
+    0 25px 60px rgba(0, 0, 0, 0.5),
+    0 0 25px rgba(255, 215, 0, 0.12);
+  transition: transform 0.4s ease, box-shadow 0.4s ease;
+}
+
+.blog-card:hover {
+  transform: translateY(-8px);
+  box-shadow:
+    0 30px 70px rgba(0, 0, 0, 0.55),
+    0 0 30px rgba(255, 166, 81, 0.2);
+}
+
+.blog-thumb img {
+  width: 100%;
+  height: clamp(180px, 32vh, 220px);
+  object-fit: cover;
+}
+
+.blog-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: clamp(1.6rem, 3vw, 2rem);
+}
+
+.blog-body h3 {
+  margin: 0;
+  font-size: clamp(1.1rem, 2vw, 1.4rem);
+  color: var(--white);
+}
+
+.blog-body p {
+  margin: 0;
+  color: rgba(232, 234, 237, 0.82);
+  line-height: 1.6;
+}
+
+.blog-link {
+  margin-top: auto;
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: var(--gold);
+  text-decoration: none;
+}
+
+.blog-link:hover {
+  text-decoration: underline;
+}
+
+/* Responsive tweaks */
+@media (max-width: 1024px) {
+  .vault-card {
+    flex: 0 0 clamp(240px, 60vw, 320px);
+    height: clamp(340px, 55vh, 400px);
+  }
+  .testimonials-slider .testimonial-card,
+  .blog-card {
+    flex: 0 0 clamp(240px, 65vw, 320px);
+  }
+}
+
+@media (max-width: 768px) {
+  .slider-wrapper {
+    gap: 1.2rem;
+    padding-right: 1.5rem;
+  }
+  .vault-card.is-active {
+    width: 92vw;
+    max-height: 88vh;
+  }
+  .team-photo-full {
+    height: clamp(200px, 40vh, 280px);
+  }
+}
+
+@media (max-width: 480px) {
+  .carousel-nav {
+    display: none;
+  }
+  .slider-wrapper {
+    padding-right: 0.5rem;
+  }
+  .vault-face {
+    padding: 1.8rem;
+  }
+  .vault-content h3 {
+    font-size: 1.3rem;
+  }
+}

--- a/assets/css/components/cursor.css
+++ b/assets/css/components/cursor.css
@@ -1,0 +1,26 @@
+.cursor,
+.cursor-follower {
+  border-radius: 50%;
+  position: fixed;
+  pointer-events: none;
+  z-index: 9999;
+  mix-blend-mode: difference;
+  will-change: transform;
+  top: -50px;
+  left: -50px;
+  transform-origin: center;
+}
+.cursor {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--gold);
+  transition: transform 0.15s;
+  box-shadow: 0 0 10px rgba(212, 175, 55, 0.6);
+}
+.cursor-follower {
+  width: 50px;
+  height: 50px;
+  border: 1px solid rgba(212, 175, 55, 0.4);
+  z-index: 9998;
+  transition: transform 0.3s;
+}

--- a/assets/css/components/forms.css
+++ b/assets/css/components/forms.css
@@ -1,0 +1,113 @@
+.blog-content {
+  padding: 2rem 1.5rem;
+}
+.blog-date {
+  font-size: 0.75rem;
+  background: linear-gradient(90deg, #ff6b35, #d4af37, #4a9b8e);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  margin-bottom: 0.8rem;
+  font-weight: 700;
+}
+.blog-title {
+  font-size: 1.3rem;
+  color: var(--white);
+  margin-bottom: 0.6rem;
+  font-weight: 800;
+  line-height: 1.3;
+}
+.blog-subtitle {
+  font-size: 0.9rem;
+  color: var(--gold);
+  margin-bottom: 0.8rem;
+  font-weight: 600;
+}
+.blog-excerpt {
+  font-size: 0.9rem;
+  color: var(--white-dim);
+  line-height: 1.6;
+}
+.contact-form {
+  max-width: 700px;
+  width: 100%;
+  margin: 3rem 0 0;
+}
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1.5rem;
+  margin-bottom: 1.5rem;
+}
+.form-group {
+  width: 100%;
+}
+.form-group.full-width {
+  grid-column: 1/-1;
+}
+.form-input,
+.form-select,
+.form-textarea {
+  width: 100%;
+  padding: 1.2rem;
+  background: rgba(13, 27, 42, 0.9);
+  border: 2px solid rgba(74, 155, 142, 0.3);
+  color: var(--white);
+  font-family: inherit;
+  font-size: 0.95rem;
+  transition: all 0.4s;
+  border-radius: 6px;
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.4);
+}
+.form-input:focus,
+.form-select:focus,
+.form-textarea:focus {
+  outline: 0;
+  border-color: var(--orange);
+  background: rgba(13, 27, 42, 0.95);
+  box-shadow: 0 0 20px rgba(255, 107, 53, 0.3);
+}
+.form-textarea {
+  resize: vertical;
+  min-height: 140px;
+}
+.form-submit {
+  width: 100%;
+  padding: 1.2rem;
+  background: rgba(10, 14, 20, 0.9);
+  border: 2px solid var(--gold);
+  color: var(--gold);
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 0.9rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: all 0.5s;
+  position: relative;
+  overflow: hidden;
+  border-radius: 6px;
+  box-shadow: 0 0 20px rgba(212, 175, 55, 0.3);
+}
+.form-submit::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  background: linear-gradient(135deg, var(--orange), var(--gold), var(--teal));
+  transition: all 0.5s;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  z-index: -1;
+}
+.form-submit:hover {
+  color: #000;
+  transform: translateY(-3px);
+  box-shadow: 0 10px 30px rgba(255, 107, 53, 0.5);
+}
+.form-submit:hover::before {
+  width: 700px;
+  height: 700px;
+}

--- a/assets/css/components/loader.css
+++ b/assets/css/components/loader.css
@@ -1,0 +1,90 @@
+.loader {
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(
+      ellipse at 50% 20%,
+      rgba(255, 183, 0, 0.08),
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse at 50% 80%,
+      rgba(255, 107, 53, 0.06),
+      transparent 70%
+    ),
+    #0a0e14;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 10000;
+  transition:
+    opacity 0.8s,
+    visibility 0.8s;
+}
+.loader.hidden {
+  opacity: 0;
+  visibility: hidden;
+  pointer-events: none;
+}
+.loader-tower {
+  width: min(200px, 40vw);
+  height: auto;
+  margin-bottom: 2rem;
+  filter: drop-shadow(0 10px 30px rgba(212, 175, 55, 0.3));
+}
+.loader-tower path,
+.loader-tower rect,
+.loader-tower polygon {
+  stroke-dasharray: var(--len);
+  stroke-dashoffset: var(--len);
+  animation: drawPath 2s ease-out forwards;
+}
+@keyframes drawPath {
+  to {
+    stroke-dashoffset: 0;
+  }
+}
+.loader-text {
+  font-size: clamp(1rem, 3vw, 1.5rem);
+  font-weight: 800;
+  letter-spacing: 0.25em;
+  color: var(--gold);
+  margin-bottom: 2rem;
+  text-shadow: 0 0 20px rgba(212, 175, 55, 0.5);
+  text-align: center;
+}
+.loader-text span {
+  display: inline-block;
+  opacity: 0;
+  animation: fadeIn 0.5s forwards;
+  animation-delay: calc(var(--i) * 0.05s);
+}
+.loader-progress {
+  font-size: clamp(1.1rem, 3vw, 1.6rem);
+  font-weight: 700;
+  color: rgba(255, 215, 0, 0.9);
+  margin-bottom: 1.5rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  text-shadow: 0 0 12px rgba(212, 175, 55, 0.6);
+}
+@keyframes fadeIn {
+  to {
+    opacity: 1;
+  }
+}
+.loader-bar-wrap {
+  width: min(350px, 80vw);
+  height: 4px;
+  background: rgba(212, 175, 55, 0.15);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.loader-bar {
+  height: 100%;
+  background: linear-gradient(90deg, #9a7c1f, #d4af37, #ffbf00, #ffd700);
+  width: 0;
+  transition: width 0.3s;
+  box-shadow: 0 0 20px rgba(212, 175, 55, 0.8);
+}

--- a/assets/css/components/scroll-indicators.css
+++ b/assets/css/components/scroll-indicators.css
@@ -1,0 +1,104 @@
+/* Scroll indicator controls */
+.scroll-indicator {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  margin: 3.5rem auto 0;
+  width: min(100%, 480px);
+  padding: 0;
+  text-align: center;
+  opacity: 0;
+  pointer-events: none;
+  cursor: pointer;
+  transform: translateY(12px);
+  transition: opacity 0.45s ease, transform 0.45s ease, filter 0.45s ease;
+}
+
+section.visible + .scroll-indicator {
+  opacity: 0.9;
+  transform: translateY(0);
+  pointer-events: auto;
+}
+
+.scroll-indicator:hover {
+  filter: drop-shadow(0 0 12px rgba(212, 175, 55, 0.55));
+}
+
+.scroll-text {
+  font-size: 0.72rem;
+  letter-spacing: 0.34em;
+  color: var(--gold);
+  text-transform: uppercase;
+  font-weight: 600;
+  text-shadow: 0 0 12px rgba(212, 175, 55, 0.45);
+  animation: textFloat 3.2s ease-in-out infinite;
+}
+
+@keyframes textFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-6px);
+  }
+}
+
+.scroll-icon {
+  width: 26px;
+  height: 46px;
+  border: 2px solid var(--gold);
+  border-radius: 18px;
+  position: relative;
+  box-shadow: 0 0 8px rgba(212, 175, 55, 0.28);
+  overflow: hidden;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.scroll-icon::before {
+  content: "";
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 4px;
+  height: 10px;
+  border-radius: 4px;
+  background: linear-gradient(180deg, rgba(255, 215, 0, 0.9), rgba(255, 140, 0, 0.65));
+  transform: translateX(-50%);
+  animation: scrollDot 2.2s ease-in-out infinite;
+  box-shadow: 0 0 8px rgba(255, 215, 0, 0.5);
+}
+
+.scroll-indicator:hover .scroll-icon {
+  box-shadow: 0 0 12px rgba(255, 215, 0, 0.5);
+}
+
+@keyframes scrollDot {
+  0% {
+    opacity: 0;
+    transform: translate(-50%, -6px);
+  }
+  40% {
+    opacity: 1;
+    transform: translate(-50%, 6px);
+  }
+  80% {
+    opacity: 0;
+    transform: translate(-50%, 16px);
+  }
+  100% {
+    opacity: 0;
+    transform: translate(-50%, 16px);
+  }
+}
+
+@media (max-width: 768px) {
+  .scroll-indicator {
+    margin-top: 2.5rem;
+    width: 100%;
+    padding-inline: 0;
+  }
+}

--- a/assets/css/components/tower-effects.css
+++ b/assets/css/components/tower-effects.css
@@ -1,0 +1,48 @@
+#tower3DContainer {
+  position: fixed;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(100vw, 1200px);
+  height: 100vh;
+  z-index: 0;
+  pointer-events: none;
+  background: transparent;
+  border: none;
+  box-shadow: none;
+}
+#tower3DContainer canvas {
+  display: block;
+  width: 100% !important;
+  height: 100% !important;
+}
+#particleCanvas {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 1;
+  opacity: 0.7;
+}
+.light-glow {
+  position: fixed;
+  width: 600px;
+  height: 600px;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    rgba(212, 175, 55, 0.4),
+    rgba(255, 107, 53, 0.2),
+    transparent
+  );
+  filter: blur(100px);
+  pointer-events: none;
+  z-index: 2;
+  opacity: 0;
+  transition: opacity 1s;
+}
+.light-glow.active {
+  opacity: 1;
+}

--- a/assets/css/layout/footer.css
+++ b/assets/css/layout/footer.css
@@ -1,0 +1,100 @@
+footer {
+  padding: 4rem 5%;
+  border-top: 1px solid rgba(74, 155, 142, 0.3);
+  margin-top: 8rem;
+  position: relative;
+  z-index: 20;
+  background: rgba(10, 14, 20, 0.5);
+}
+.sub-footer {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 3rem;
+  margin-bottom: 3rem;
+}
+.footer-section h3 {
+  font-size: 1rem;
+  color: var(--gold);
+  margin-bottom: 1.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-weight: 800;
+}
+.footer-bio {
+  color: var(--white-dim);
+  line-height: 1.7;
+  font-size: 0.9rem;
+}
+.footer-menu {
+  list-style: none;
+}
+.footer-menu li {
+  margin-bottom: 0.8rem;
+}
+.footer-menu a {
+  color: var(--white-dim);
+  text-decoration: none;
+  font-size: 0.9rem;
+  transition: color 0.3s;
+}
+.footer-menu a:hover {
+  color: var(--gold);
+}
+.footer-contact {
+  color: var(--white-dim);
+  font-size: 0.9rem;
+  line-height: 1.8;
+}
+.footer-contact a {
+  color: var(--white);
+  text-decoration: none;
+  transition: color 0.3s;
+}
+.footer-contact a:hover {
+  color: var(--gold);
+}
+.newsletter-form {
+  display: flex;
+  gap: 0.5rem;
+}
+.newsletter-input {
+  flex: 1;
+  padding: 0.8rem;
+  background: rgba(13, 27, 42, 0.9);
+  border: 2px solid rgba(74, 155, 142, 0.3);
+  color: var(--white);
+  font-family: inherit;
+  font-size: 0.85rem;
+  border-radius: 4px;
+}
+.newsletter-btn {
+  padding-inline: 1.8rem;
+  min-width: 160px;
+}
+.footer-bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding-top: 2rem;
+  border-top: 1px solid rgba(74, 155, 142, 0.2);
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.footer-text {
+  font-size: 0.9rem;
+  color: var(--white-dim);
+  letter-spacing: 0.1em;
+}
+.footer-links {
+  display: flex;
+  gap: 2rem;
+}
+.footer-links a {
+  color: var(--white-dim);
+  text-decoration: none;
+  font-size: 0.85rem;
+  transition: color 0.3s;
+}
+.footer-links a:hover {
+  color: var(--gold);
+}

--- a/assets/css/layout/navigation.css
+++ b/assets/css/layout/navigation.css
@@ -1,0 +1,300 @@
+nav {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  padding: 1.5rem 5%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 1000;
+  opacity: 0;
+  transition:
+    opacity 2s ease 2s,
+    background 0.3s;
+  backdrop-filter: blur(20px);
+  border-bottom: 1px solid rgba(74, 155, 142, 0.15);
+}
+nav.visible {
+  opacity: 1;
+}
+nav.scrolled {
+  background: rgba(10, 14, 20, 0.85);
+  box-shadow:
+    0 4px 30px rgba(0, 0, 0, 0.9),
+    0 0 15px rgba(255, 107, 53, 0.1);
+}
+.nav-logo {
+  font-size: 1.5rem;
+  font-weight: 900;
+  letter-spacing: 0.1em;
+  background: linear-gradient(135deg, #ffd700, #ff6b35, #d4af37);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.3s;
+  filter: drop-shadow(0 0 10px rgba(212, 175, 55, 0.3));
+}
+.nav-logo:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(0 0 15px rgba(255, 107, 53, 0.6));
+}
+.nav-menu {
+  display: flex;
+  gap: 2rem;
+  list-style: none;
+  align-items: center;
+}
+.nav-menu > li {
+  position: relative;
+}
+.nav-menu a {
+  color: var(--white-dim);
+  text-decoration: none;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-weight: 600;
+  transition: all 0.3s;
+  padding: 0.5rem 0;
+  display: block;
+  position: relative;
+}
+.nav-menu a::after {
+  content: "";
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  width: 0;
+  height: 2px;
+  background: linear-gradient(90deg, var(--orange), var(--gold));
+  transition: width 0.3s;
+}
+.nav-menu a:hover {
+  color: var(--gold);
+}
+.nav-menu a:hover::after {
+  width: 100%;
+}
+.nav-cta {
+  font-size: 0.75rem;
+  letter-spacing: 0.2em;
+  padding-inline: 1.6rem;
+  border-radius: 6px;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+.nav-menu .nav-cta.button-glow {
+  padding: 0.95rem 2.4rem;
+  border-radius: 10px;
+  border: 4px solid rgba(9, 14, 22, 0.55);
+}
+
+.nav-cta::after {
+  display: none;
+}
+.nav-dropdown {
+  position: relative;
+}
+.nav-dropdown > a {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+.nav-dropdown > a::before {
+  content: "▸";
+  font-size: 0.9rem;
+  transition: transform 0.3s;
+}
+.nav-dropdown:hover > a::before {
+  transform: rotate(90deg);
+}
+.nav-dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: rgba(10, 14, 20, 0.98);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(74, 155, 142, 0.3);
+  border-radius: 8px;
+  padding: 1rem 0;
+  min-width: 200px;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(-10px);
+  transition: all 0.3s;
+  box-shadow:
+    0 10px 40px rgba(0, 0, 0, 0.7),
+    0 0 15px rgba(255, 107, 53, 0.15);
+  list-style: none;
+}
+.nav-dropdown:hover .nav-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+.nav-dropdown-menu a {
+  padding: 0.8rem 1.5rem;
+  font-size: 0.75rem;
+}
+.nav-dropdown-menu a:hover {
+  background: rgba(255, 107, 53, 0.1);
+}
+.hamburger {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+  z-index: 1001;
+  width: 30px;
+  height: 25px;
+  position: relative;
+  transition: transform 0.4s;
+}
+.hamburger span {
+  width: 100%;
+  height: 2px;
+  background: var(--gold);
+  transition: all 0.4s;
+  border-radius: 2px;
+  transform-origin: center;
+  box-shadow: 0 0 5px rgba(212, 175, 55, 0.4);
+}
+.hamburger.active {
+  transform: rotate(180deg);
+}
+.hamburger.active span:nth-child(1) {
+  transform: rotate(45deg) translate(5px, 5px);
+}
+.hamburger.active span:nth-child(2) {
+  opacity: 0;
+  transform: translateX(-10px);
+}
+.hamburger.active span:nth-child(3) {
+  transform: rotate(-45deg) translate(7px, -6px);
+}
+.mobile-menu {
+  position: fixed;
+  top: 0;
+  right: -100%;
+  width: 100%;
+  max-width: 400px;
+  height: 100vh;
+  background: linear-gradient(
+    135deg,
+    rgba(10, 14, 20, 0.98),
+    rgba(13, 27, 42, 0.98)
+  );
+  backdrop-filter: blur(30px);
+  z-index: 999;
+  padding: 6rem 2rem 2rem;
+  transition: right 0.5s;
+  overflow-y: auto;
+  box-shadow: -5px 0 30px rgba(0, 0, 0, 0.7);
+  border-left: 1px solid rgba(74, 155, 142, 0.3);
+}
+.mobile-menu.active {
+  right: 0;
+}
+.mobile-menu-links {
+  list-style: none;
+  margin-bottom: 2rem;
+}
+.mobile-menu-links > li {
+  margin-bottom: 0.5rem;
+}
+.mobile-menu-links a {
+  color: var(--white);
+  text-decoration: none;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-weight: 600;
+  padding: 1rem;
+  display: block;
+  border-left: 3px solid transparent;
+  transition: all 0.3s;
+  position: relative;
+  font-family: Montserrat, sans-serif;
+}
+.mobile-menu-links a::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 0;
+  height: 100%;
+  background: rgba(255, 107, 53, 0.08);
+  transition: width 0.3s;
+  z-index: -1;
+}
+.mobile-menu-links a:hover {
+  color: var(--gold);
+  border-left-color: var(--orange);
+}
+.mobile-menu-links a:hover::before {
+  width: 100%;
+}
+.mobile-submenu {
+  padding-left: 1rem;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.3s;
+}
+.mobile-submenu.active {
+  max-height: 300px;
+}
+.mobile-submenu a {
+  font-size: 0.95rem;
+  padding: 0.8rem 1rem;
+}
+.mobile-dropdown-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  cursor: pointer;
+  font-size: 1.1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-weight: 600;
+  font-family: Montserrat, sans-serif;
+  color: var(--white);
+  padding: 1rem;
+  border-left: 3px solid transparent;
+  transition: all 0.3s;
+}
+.mobile-dropdown-toggle::after {
+  content: "▼";
+  font-size: 0.7rem;
+  transition: transform 0.3s;
+}
+.mobile-dropdown-toggle.active::after {
+  transform: rotate(180deg);
+}
+.mobile-dropdown-toggle:hover {
+  color: var(--gold);
+  border-left-color: var(--orange);
+}
+.mobile-menu-contacts {
+  border-top: 1px solid rgba(74, 155, 142, 0.3);
+  padding-top: 1.5rem;
+}
+.mobile-menu-contacts h3 {
+  font-size: 0.9rem;
+  color: var(--gold);
+  margin-bottom: 1rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+}
+.mobile-menu-contacts p {
+  font-size: 0.85rem;
+  margin-bottom: 0.5rem;
+  color: var(--white-dim);
+}
+.mobile-menu-contacts a {
+  color: var(--white);
+  text-decoration: none;
+  transition: color 0.3s;
+}

--- a/assets/css/layout/sections.css
+++ b/assets/css/layout/sections.css
@@ -1,0 +1,255 @@
+section {
+  min-height: 120vh;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  position: relative;
+  padding: 9rem var(--left) 12.5rem 5%;
+  overflow: visible;
+  opacity: 0;
+  transform: translateY(60px);
+  transition:
+    opacity 1s,
+    transform 1s;
+  z-index: 20;
+}
+section.visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+.section-content {
+  max-width: min(100%, 1040px);
+  width: 100%;
+  text-align: left;
+  z-index: 20;
+  position: relative;
+  padding: 3.5rem;
+  border-radius: 15px;
+  transform: translate3d(0, 35px, 0) scale(0.98);
+  opacity: 0;
+  transition:
+    transform 1s cubic-bezier(0.19, 1, 0.22, 1),
+    opacity 1s ease;
+}
+.section-bg {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 78%;
+  max-width: 1040px;
+  height: 82%;
+  z-index: -1;
+  background-size: cover;
+  background-position: center;
+  opacity: 0;
+  filter: brightness(0.55) contrast(1.3) saturate(1.4) sepia(0.3);
+  transition:
+    opacity 2s,
+    filter 2s;
+  -webkit-mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.8) 0%,
+    rgba(0, 0, 0, 0.5) 60%,
+    transparent 100%
+  );
+  mask-image: linear-gradient(
+    to bottom,
+    rgba(0, 0, 0, 0.8) 0%,
+    rgba(0, 0, 0, 0.5) 60%,
+    transparent 100%
+  );
+  mix-blend-mode: luminosity;
+  border-radius: 20px;
+}
+#about .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1559136555-9303baea8ebd?w=1600&auto=format&fit=crop&q=80");
+}
+#mission .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1552664730-d307ca884978?w=1600&auto=format&fit=crop&q=80");
+}
+#vision .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=1600&auto=format&fit=crop&q=80");
+}
+#values .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1553484771-371a605b060b?w=1600&auto=format&fit=crop&q=80");
+}
+#services .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1559028012-481c04fa702d?w=1600&auto=format&fit=crop&q=80");
+}
+#team .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1556761175-5973dc0f32e7?w=1600&auto=format&fit=crop&q=80");
+}
+#testimonials .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1551836026-d5c88ac5d69a?w=1600&auto=format&fit=crop&q=80");
+}
+#blog .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1586953208448-b95a79798f07?w=1600&auto=format&fit=crop&q=80");
+}
+#contact .section-bg {
+  background-image: url("https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=1600&auto=format&fit=crop&q=80");
+}
+section.visible .section-bg {
+  opacity: 1;
+  filter: brightness(0.55) contrast(1.4) saturate(1.5) sepia(0.3);
+  animation: sectionGlow 2.4s ease forwards;
+}
+section.visible .section-content {
+  transform: translate3d(0, 0, 0) scale(1);
+  opacity: 1;
+}
+.section-subtitle {
+  font-size: 0.9rem;
+  letter-spacing: 0.4em;
+  color: var(--gold);
+  margin-bottom: 1.5rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  opacity: 0;
+  transition: opacity 1s 0.2s;
+  text-shadow: 0 0 15px rgba(255, 107, 53, 0.5);
+  animation: textFloat 4s ease-in-out infinite;
+}
+section.visible .section-subtitle {
+  opacity: 1;
+}
+.section-title {
+  font-size: clamp(2.5rem, 6vw, 4.5rem);
+  font-weight: 900;
+  margin-bottom: 2rem;
+  line-height: 1;
+  background: linear-gradient(
+    135deg,
+    var(--white),
+    var(--gold-light),
+    var(--orange),
+    var(--teal)
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  text-transform: uppercase;
+  letter-spacing: -0.02em;
+  opacity: 0;
+  transition: opacity 1s 0.4s;
+  position: relative;
+  filter: drop-shadow(0 2px 15px rgba(255, 107, 53, 0.4));
+  animation: titleFloat 5s ease-in-out infinite;
+}
+@keyframes titleFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-8px);
+  }
+}
+section.visible .section-title {
+  opacity: 1;
+}
+.section-text {
+  font-size: 1.15rem;
+  line-height: 1.9;
+  color: var(--white);
+  font-weight: 400;
+  margin-bottom: 2.5rem;
+  opacity: 0;
+  transition: opacity 1s 0.6s;
+  text-shadow: 0 1px 3px rgba(0, 0, 0, 0.6);
+  animation: textFloat 6s ease-in-out infinite;
+}
+section.visible .section-text {
+  opacity: 1;
+}
+
+@keyframes sectionGlow {
+  0% {
+    transform: translate(-50%, -50%) scale(1);
+    filter: brightness(0.5) contrast(1.3) saturate(1.3) sepia(0.25);
+  }
+  45% {
+    transform: translate(-50%, -52%) scale(1.02);
+    filter: brightness(0.65) contrast(1.45) saturate(1.55) sepia(0.3);
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1);
+    filter: brightness(0.55) contrast(1.4) saturate(1.5) sepia(0.3);
+  }
+}
+.hero-title {
+  font-size: clamp(2.8rem, 7.5vw, 6rem);
+  font-weight: 900;
+  line-height: 0.95;
+  margin-bottom: 2rem;
+  background: linear-gradient(
+    135deg,
+    #ffd700,
+    #ff6b35,
+    #4a9b8e,
+    var(--white),
+    var(--gold)
+  );
+  background-size: 300% 100%;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  letter-spacing: -0.03em;
+  filter: drop-shadow(0 3px 20px rgba(255, 107, 53, 0.6));
+  animation: heroFloat 4s ease-in-out infinite;
+}
+@keyframes heroFloat {
+  0%,
+  100% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-12px);
+  }
+}
+.cta-button {
+  display: inline-block;
+  padding: 1.2rem 3rem;
+  background: rgba(10, 14, 20, 0.9);
+  border: 2px solid var(--gold);
+  color: var(--gold);
+  text-decoration: none;
+  text-transform: uppercase;
+  letter-spacing: 0.25em;
+  font-size: 0.85rem;
+  font-weight: 700;
+  transition: all 0.5s;
+  position: relative;
+  overflow: hidden;
+  border-radius: 4px;
+  box-shadow:
+    0 0 20px rgba(212, 175, 55, 0.3),
+    inset 0 0 10px rgba(255, 107, 53, 0.1);
+}
+.cta-button::before {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 0;
+  height: 0;
+  background: linear-gradient(135deg, var(--orange), var(--gold), var(--teal));
+  transition: all 0.5s;
+  transform: translate(-50%, -50%);
+  border-radius: 50%;
+  z-index: -1;
+}
+.cta-button:hover {
+  color: #000;
+  transform: translateY(-3px);
+  box-shadow: 0 10px 30px rgba(255, 107, 53, 0.5);
+}
+.cta-button:hover::before {
+  width: 500px;
+  height: 500px;
+}
+.services-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  margin-top: 3rem;
+}

--- a/assets/css/utilities/responsive.css
+++ b/assets/css/utilities/responsive.css
@@ -1,0 +1,93 @@
+@media (max-width: 1024px) {
+  .nav-menu {
+    display: none;
+  }
+  section {
+    min-height: auto;
+  }
+  .vault-card,
+  .testimonial-card,
+  .blog-card,
+  .team-card {
+    min-width: 280px;
+    max-width: 280px;
+    margin-inline-start: 1.1rem;
+    margin-block-start: 1.6rem;
+  }
+  .vault-card {
+    height: 380px;
+  }
+  #tower3DContainer {
+    opacity: 0.4 !important;
+    width: min(90vw, 520px);
+    left: 50%;
+    transform: translateX(-50%);
+  }
+  .sub-footer {
+    grid-template-columns: 1fr 1fr;
+  }
+  .cursor,
+  .cursor-follower {
+    display: none;
+  }
+}
+@media (max-width: 768px) {
+  nav {
+    padding: 1rem 5%;
+  }
+  section {
+    padding: 5rem 5%;
+  }
+  .section-content {
+    padding: 2.5rem 1.5rem;
+  }
+  .mobile-menu .nav-cta {
+    width: 100%;
+    justify-content: center;
+  }
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+  .vault-card,
+  .testimonial-card,
+  .blog-card,
+  .team-card {
+    min-width: 260px;
+    max-width: 260px;
+    margin-inline-start: 0.9rem;
+    margin-block-start: 1.4rem;
+  }
+  .vault-card {
+    height: 360px;
+  }
+  .services-grid {
+    grid-template-columns: 1fr;
+  }
+  .sub-footer {
+    grid-template-columns: 1fr;
+  }
+  .footer-bottom {
+    flex-direction: column;
+    text-align: center;
+  }
+  .hero-title {
+    font-size: clamp(2.5rem, 7vw, 5rem);
+  }
+}
+@media (max-width: 480px) {
+  .section-content {
+    padding: 2rem 1rem;
+  }
+  .vault-card,
+  .testimonial-card,
+  .blog-card,
+  .team-card {
+    min-width: 240px;
+    max-width: 240px;
+    margin-inline-start: 0.75rem;
+    margin-block-start: 1.25rem;
+  }
+  .mobile-menu {
+    max-width: 100%;
+  }
+}

--- a/assets/js/core/audio.js
+++ b/assets/js/core/audio.js
@@ -1,0 +1,166 @@
+(() => {
+  const hasAudioSupport =
+    typeof window.AudioContext !== "undefined" ||
+    typeof window.webkitAudioContext !== "undefined";
+  let audioContext = null;
+
+  function getContext() {
+    if (!hasAudioSupport) {
+      return null;
+    }
+    if (!audioContext) {
+      const Ctor = window.AudioContext || window.webkitAudioContext;
+      audioContext = new Ctor();
+    }
+    return audioContext;
+  }
+
+  function createNoiseBuffer(ctx, duration = 0.25) {
+    const length = Math.max(1, Math.floor(ctx.sampleRate * duration));
+    const buffer = ctx.createBuffer(1, length, ctx.sampleRate);
+    const data = buffer.getChannelData(0);
+    for (let i = 0; i < length; i += 1) {
+      const fade = 1 - i / length;
+      data[i] = (Math.random() * 2 - 1) * fade * 0.6;
+    }
+    return buffer;
+  }
+
+  function playTone({
+    type = "sine",
+    frequencyStart = 220,
+    frequencyEnd = 220,
+    duration = 0.4,
+    gainStart = 0.0001,
+    gainPeak = 0.12,
+    gainEnd = 0.0001,
+    startTime = 0,
+    curve = "exponential",
+  }) {
+    const ctx = getContext();
+    if (!ctx) {
+      return;
+    }
+    const now = ctx.currentTime + startTime;
+    const oscillator = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    oscillator.type = type;
+    oscillator.frequency.setValueAtTime(frequencyStart, now);
+    if (curve === "exponential" && frequencyEnd > 0) {
+      oscillator.frequency.exponentialRampToValueAtTime(
+        frequencyEnd,
+        now + duration,
+      );
+    } else {
+      oscillator.frequency.linearRampToValueAtTime(
+        frequencyEnd,
+        now + duration,
+      );
+    }
+
+    gain.gain.setValueAtTime(gainStart, now);
+    gain.gain.exponentialRampToValueAtTime(gainPeak, now + 0.04);
+    gain.gain.exponentialRampToValueAtTime(gainEnd, now + duration);
+
+    oscillator.connect(gain);
+    gain.connect(ctx.destination);
+
+    oscillator.start(now);
+    oscillator.stop(now + duration + 0.05);
+  }
+
+  function playPaperFlip() {
+    const ctx = getContext();
+    if (!ctx) {
+      return;
+    }
+    const now = ctx.currentTime;
+    const osc = ctx.createOscillator();
+    const gain = ctx.createGain();
+
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(220, now);
+    osc.frequency.linearRampToValueAtTime(320, now + 0.08);
+    osc.frequency.linearRampToValueAtTime(180, now + 0.28);
+
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.035, now + 0.05);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.3);
+
+    const noise = ctx.createBufferSource();
+    noise.buffer = createNoiseBuffer(ctx, 0.18);
+    const noiseGain = ctx.createGain();
+    noiseGain.gain.setValueAtTime(0.0001, now);
+    noiseGain.gain.linearRampToValueAtTime(0.018, now + 0.04);
+    noiseGain.gain.linearRampToValueAtTime(0.0001, now + 0.2);
+
+    osc.connect(gain);
+    noise.connect(noiseGain);
+    gain.connect(ctx.destination);
+    noiseGain.connect(ctx.destination);
+
+    osc.start(now);
+    osc.stop(now + 0.36);
+    noise.start(now);
+    noise.stop(now + 0.21);
+  }
+
+  function playHover() {
+    playTone({
+      type: "sine",
+      frequencyStart: 520,
+      frequencyEnd: 680,
+      duration: 0.25,
+      gainPeak: 0.02,
+      gainEnd: 0.0001,
+    });
+  }
+
+  function playRelease() {
+    playTone({
+      type: "sine",
+      frequencyStart: 360,
+      frequencyEnd: 220,
+      duration: 0.3,
+      gainPeak: 0.028,
+    });
+  }
+
+  function playMenu(open) {
+    playTone({
+      type: "sine",
+      frequencyStart: open ? 320 : 420,
+      frequencyEnd: open ? 520 : 240,
+      duration: 0.28,
+      gainPeak: 0.04,
+    });
+  }
+
+  function play(name) {
+    switch (name) {
+      case "card-flip":
+        playPaperFlip();
+        break;
+      case "card-hover":
+        playHover();
+        break;
+      case "card-close":
+        playRelease();
+        break;
+      case "menu-open":
+        playMenu(true);
+        break;
+      case "menu-close":
+        playMenu(false);
+        break;
+      default:
+        break;
+    }
+  }
+
+  window.uiSound = {
+    play,
+    ensure: getContext,
+  };
+})();

--- a/assets/js/core/cards.js
+++ b/assets/js/core/cards.js
@@ -1,0 +1,171 @@
+(() => {
+  const overlay = document.getElementById("cardOverlay");
+  const vaultCards = Array.from(document.querySelectorAll(".vault-card"));
+  const audio = window.uiSound || null;
+  let activeCard = null;
+  let unlockTimeout = null;
+
+  function dimGroup(target, dimmed) {
+    const group = target.dataset.vaultGroup || "global";
+    vaultCards.forEach((card) => {
+      if (card === target) {
+        return;
+      }
+      if ((card.dataset.vaultGroup || "global") === group) {
+        card.classList.toggle("is-muted", dimmed);
+      }
+    });
+  }
+
+  function unlockCard(card) {
+    card.classList.add("is-unlocked");
+    if (unlockTimeout) {
+      window.clearTimeout(unlockTimeout);
+    }
+    unlockTimeout = window.setTimeout(() => {
+      unlockTimeout = null;
+    }, 450);
+  }
+
+  function lockCard(card) {
+    if (unlockTimeout) {
+      window.clearTimeout(unlockTimeout);
+      unlockTimeout = null;
+    }
+    window.setTimeout(() => {
+      card.classList.remove("is-unlocked");
+    }, 300);
+  }
+
+  function closeActiveCard() {
+    if (!activeCard) {
+      return;
+    }
+    activeCard.classList.remove("is-active");
+    lockCard(activeCard);
+    dimGroup(activeCard, false);
+    activeCard = null;
+    if (overlay) {
+      overlay.classList.remove("active");
+    }
+    document.body.classList.remove("card-open");
+    document.documentElement.classList.remove("card-open");
+    if (audio) {
+      audio.play("card-close");
+    }
+  }
+
+  function focusCard(card) {
+    if (activeCard === card) {
+      closeActiveCard();
+      return;
+    }
+    if (activeCard) {
+      closeActiveCard();
+    }
+    unlockCard(card);
+    card.classList.add("is-active");
+    dimGroup(card, true);
+    if (overlay) {
+      overlay.classList.add("active");
+    }
+    document.body.classList.add("card-open");
+    document.documentElement.classList.add("card-open");
+    activeCard = card;
+    const closeButton = card.querySelector(".vault-close");
+    if (closeButton) {
+      try {
+        closeButton.focus({ preventScroll: true });
+      } catch (error) {
+        closeButton.focus();
+      }
+    }
+    if (audio) {
+      audio.play("card-flip");
+    }
+  }
+
+  function onCardClick(card, event) {
+    const closeButton = event.target.closest(".vault-close");
+    if (closeButton) {
+      event.stopPropagation();
+      closeActiveCard();
+      return;
+    }
+    const link = event.target.closest("a");
+    if (link) {
+      return;
+    }
+    focusCard(card);
+  }
+
+  function bindCard(card) {
+    if (!card.dataset.vaultGroup) {
+      card.dataset.vaultGroup = "global";
+    }
+    if (!card.hasAttribute("tabindex")) {
+      card.setAttribute("tabindex", "0");
+    }
+
+    card.addEventListener("click", (event) => {
+      onCardClick(card, event);
+    });
+
+    card.addEventListener(
+      "pointerdown",
+      (event) => {
+        if (event.pointerType === "touch") {
+          onCardClick(card, event);
+        }
+      },
+      { passive: true },
+    );
+
+    card.addEventListener("mouseenter", () => {
+      card.classList.add("is-hovered");
+      dimGroup(card, true);
+      if (audio) {
+        audio.play("card-hover");
+      }
+    });
+
+    card.addEventListener("mouseleave", () => {
+      card.classList.remove("is-hovered");
+      if (!card.classList.contains("is-active")) {
+        dimGroup(card, false);
+      }
+    });
+
+    card.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        focusCard(card);
+      }
+    });
+  }
+
+  vaultCards.forEach(bindCard);
+
+  if (overlay) {
+    overlay.addEventListener("click", closeActiveCard);
+  }
+
+  window.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      closeActiveCard();
+    }
+  });
+
+  window.addEventListener(
+    "resize",
+    () => {
+      if (activeCard) {
+        // ensure active card remains centered on resize
+        activeCard.classList.add("is-active");
+      }
+    },
+    { passive: true },
+  );
+
+  window.closeActiveCard = closeActiveCard;
+})();

--- a/assets/js/core/cursor.js
+++ b/assets/js/core/cursor.js
@@ -1,0 +1,101 @@
+(() => {
+  if (window.innerWidth <= 1024) {
+    return;
+  }
+
+  const cursor = document.querySelector(".cursor");
+  const follower = document.querySelector(".cursor-follower");
+
+  if (!cursor || !follower) {
+    return;
+  }
+
+  let mouseX = window.innerWidth / 2;
+  let mouseY = window.innerHeight / 2;
+  let cursorX = mouseX;
+  let cursorY = mouseY;
+  let followerX = mouseX;
+  let followerY = mouseY;
+  let cursorScale = 1;
+  let followerScale = 1;
+  let rafId = 0;
+
+  function applyTransforms() {
+    cursor.style.transform = `translate3d(${cursorX}px, ${cursorY}px, 0) translate3d(-50%, -50%, 0) scale(${cursorScale})`;
+    follower.style.transform = `translate3d(${followerX}px, ${followerY}px, 0) translate3d(-50%, -50%, 0) scale(${followerScale})`;
+  }
+
+  function updateCursor() {
+    cursorX += (mouseX - cursorX) * 0.6;
+    cursorY += (mouseY - cursorY) * 0.6;
+    followerX += (mouseX - followerX) * 0.18;
+    followerY += (mouseY - followerY) * 0.18;
+
+    applyTransforms();
+    rafId = window.requestAnimationFrame(updateCursor);
+  }
+
+  function enlarge() {
+    cursorScale = 2.2;
+    followerScale = 1.8;
+  }
+
+  function resetScale() {
+    cursorScale = 1;
+    followerScale = 1;
+  }
+
+  function startLoop() {
+    if (!rafId) {
+      rafId = window.requestAnimationFrame(updateCursor);
+    }
+  }
+
+  function handlePointerMove(event) {
+    if (event.pointerType && event.pointerType !== "mouse") {
+      return;
+    }
+    mouseX = event.clientX;
+    mouseY = event.clientY;
+    cursorX = mouseX;
+    cursorY = mouseY;
+    followerX += (mouseX - followerX) * 0.35;
+    followerY += (mouseY - followerY) * 0.35;
+    startLoop();
+  }
+
+  if (window.PointerEvent) {
+    document.addEventListener("pointermove", handlePointerMove, { passive: true });
+  } else {
+    document.addEventListener(
+      "mousemove",
+      (event) => {
+        mouseX = event.clientX;
+        mouseY = event.clientY;
+        cursorX = mouseX;
+        cursorY = mouseY;
+        followerX = mouseX;
+        followerY = mouseY;
+        startLoop();
+      },
+      { passive: true },
+    );
+  }
+
+  const interactiveSelectors =
+    "a, button, .vault-card, .cta-button, .form-submit, .service-card, .team-card, .testimonial-card, .blog-card, .carousel-arrow";
+
+  document.querySelectorAll(interactiveSelectors).forEach((element) => {
+    element.addEventListener("mouseenter", () => {
+      enlarge();
+      applyTransforms();
+    });
+    element.addEventListener("mouseleave", () => {
+      resetScale();
+      applyTransforms();
+    });
+  });
+
+  applyTransforms();
+  startLoop();
+})();

--- a/assets/js/core/forms.js
+++ b/assets/js/core/forms.js
@@ -1,0 +1,62 @@
+(() => {
+  const contactForm = document.getElementById("contactForm");
+
+  function showConfirmation(submitButton, originalText) {
+    const modal = document.createElement("div");
+    modal.style.cssText = [
+      "position:fixed",
+      "top:50%",
+      "left:50%",
+      "transform:translate(-50%,-50%)",
+      "background:linear-gradient(135deg,rgba(13,27,42,0.98),rgba(10,14,20,1))",
+      "border:2px solid var(--orange)",
+      "padding:2.5rem",
+      "border-radius:10px",
+      "text-align:center",
+      "z-index:10000",
+      "box-shadow:0 20px 60px rgba(0,0,0,0.9),0 0 40px rgba(255,107,53,0.5)",
+    ].join(";");
+
+    modal.innerHTML = [
+      '<h3 style="color:var(--gold);margin-bottom:1rem;font-size:1.5rem;text-shadow:0 0 20px rgba(255,107,53,0.6)">Grazie!</h3>',
+      '<p style="color:var(--white);margin-bottom:1.5rem">Ti contatteremo presto.</p>',
+      '<button type="button" style="background:linear-gradient(135deg,var(--orange),var(--gold));color:#000;border:none;padding:0.8rem 1.5rem;border-radius:4px;cursor:pointer;font-weight:bold;box-shadow:0 4px 15px rgba(255,107,53,0.5)">OK</button>',
+    ].join("");
+
+    const dismissButton = modal.querySelector("button");
+    dismissButton?.addEventListener("click", () => {
+      modal.remove();
+    });
+
+    document.body.appendChild(modal);
+
+    window.setTimeout(() => {
+      if (modal.parentElement) {
+        modal.remove();
+      }
+    }, 3000);
+
+    submitButton.textContent = originalText;
+    submitButton.disabled = false;
+  }
+
+  if (contactForm) {
+    contactForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+
+      const submitButton = contactForm.querySelector(".form-submit");
+      if (!submitButton) {
+        return;
+      }
+
+      const originalText = submitButton.textContent || "Invia";
+      submitButton.textContent = "Invio...";
+      submitButton.disabled = true;
+
+      window.setTimeout(() => {
+        contactForm.reset();
+        showConfirmation(submitButton, originalText);
+      }, 1500);
+    });
+  }
+})();

--- a/assets/js/core/loader.js
+++ b/assets/js/core/loader.js
@@ -1,0 +1,90 @@
+(() => {
+  const loaderText = document.getElementById("loaderText");
+  const loaderBar = document.getElementById("loaderBar");
+  const loader = document.getElementById("loader");
+  const loaderProgress = document.getElementById("loaderProgress");
+  const mainNav = document.getElementById("mainNav");
+  const lightGlow1 = document.getElementById("lightGlow1");
+  const lightGlow2 = document.getElementById("lightGlow2");
+
+  const message = "SCALIAMO INSIEME LA TORRE DEL SUCCESSO";
+
+  function buildLoaderText() {
+    if (!loaderText || !message) {
+      return;
+    }
+    loaderText.innerHTML = "";
+    [...message].forEach((char, index) => {
+      const span = document.createElement("span");
+      span.textContent = char === " " ? "\u00A0" : char;
+      span.style.setProperty("--i", String(index));
+      span.style.animationDelay = `${index * 0.05}s`;
+      loaderText.appendChild(span);
+    });
+  }
+
+  function activateGlow() {
+    if (lightGlow1) {
+      lightGlow1.classList.add("active");
+    }
+    if (lightGlow2) {
+      lightGlow2.classList.add("active");
+    }
+  }
+
+  function startExperience() {
+    if (typeof window.init3DScene === "function") {
+      window.init3DScene();
+    }
+    if (typeof window.initSections === "function") {
+      window.initSections();
+    }
+    if (typeof window.initParticles === "function") {
+      window.initParticles();
+    }
+    window.setTimeout(activateGlow, 500);
+  }
+
+  function revealSite() {
+    if (loader) {
+      if (loaderProgress) {
+        loaderProgress.textContent = "100%";
+      }
+      loader.classList.add("hidden");
+    }
+    window.setTimeout(() => {
+      if (mainNav) {
+        mainNav.classList.add("visible");
+      }
+      startExperience();
+    }, 200);
+  }
+
+  function runLoader() {
+    if (!loader || !loaderBar) {
+      startExperience();
+      return;
+    }
+
+    let progress = 0;
+    const interval = window.setInterval(() => {
+      progress = Math.min(100, progress + 3 + Math.random() * 7);
+      loaderBar.style.width = `${progress}%`;
+      if (loaderProgress) {
+        loaderProgress.textContent = `${Math.round(progress)}%`;
+      }
+
+      if (progress >= 100) {
+        window.clearInterval(interval);
+        window.setTimeout(revealSite, 600);
+      }
+    }, 160);
+  }
+
+  function init() {
+    buildLoaderText();
+    runLoader();
+  }
+
+  window.addEventListener("load", init, { once: true });
+})();

--- a/assets/js/core/navigation.js
+++ b/assets/js/core/navigation.js
@@ -1,0 +1,74 @@
+(() => {
+  const hamburger = document.getElementById("hamburger");
+  const mobileMenu = document.getElementById("mobileMenu");
+  const audio = window.uiSound || null;
+
+  function toggleBodyScroll(disabled) {
+    document.body.style.overflow = disabled ? "hidden" : "";
+  }
+
+  function closeMobileMenu() {
+    const wasActive = mobileMenu && mobileMenu.classList.contains("active");
+    if (hamburger) {
+      hamburger.classList.remove("active");
+      hamburger.setAttribute("aria-expanded", "false");
+    }
+    if (mobileMenu) {
+      mobileMenu.classList.remove("active");
+    }
+    toggleBodyScroll(false);
+    if (audio && wasActive) {
+      audio.play("menu-close");
+    }
+  }
+
+  function toggleMobileSubmenu(trigger) {
+    trigger.classList.toggle("active");
+    const submenu = trigger.nextElementSibling;
+    if (submenu) {
+      submenu.classList.toggle("active");
+    }
+  }
+
+  function handleOutsideClick(event) {
+    if (!mobileMenu || !hamburger) {
+      return;
+    }
+    if (!mobileMenu.classList.contains("active")) {
+      return;
+    }
+    if (mobileMenu.contains(event.target) || hamburger.contains(event.target)) {
+      return;
+    }
+    closeMobileMenu();
+  }
+
+  if (hamburger && mobileMenu) {
+    hamburger.setAttribute("role", "button");
+    hamburger.setAttribute("tabindex", "0");
+    hamburger.setAttribute("aria-expanded", "false");
+    hamburger.addEventListener("click", () => {
+      const isActive = mobileMenu.classList.toggle("active");
+      hamburger.classList.toggle("active", isActive);
+      hamburger.setAttribute("aria-expanded", isActive ? "true" : "false");
+      toggleBodyScroll(isActive);
+      if (audio) {
+        audio.play(isActive ? "menu-open" : "menu-close");
+      }
+    });
+    hamburger.addEventListener("keydown", (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        hamburger.click();
+      }
+    });
+    document.addEventListener("click", handleOutsideClick, true);
+    document.addEventListener("touchstart", handleOutsideClick, {
+      passive: true,
+      capture: true,
+    });
+  }
+
+  window.closeMobileMenu = closeMobileMenu;
+  window.toggleMobileSubmenu = toggleMobileSubmenu;
+})();

--- a/assets/js/core/particles.js
+++ b/assets/js/core/particles.js
@@ -1,0 +1,107 @@
+(() => {
+  const canvas = document.getElementById("particleCanvas");
+  if (!canvas) {
+    return;
+  }
+
+  const ctx = canvas.getContext("2d");
+  let particles = [];
+  const mouse = { x: -999, y: -999 };
+
+  function resizeCanvas() {
+    canvas.width = window.innerWidth;
+    canvas.height = window.innerHeight;
+  }
+
+  class Particle {
+    constructor() {
+      this.reset();
+    }
+
+    reset() {
+      this.x = Math.random() * canvas.width;
+      this.y = Math.random() * canvas.height;
+      this.size = Math.random() * 2 + 1;
+      this.speedX = (Math.random() - 0.5) * 0.3;
+      this.speedY = (Math.random() - 0.5) * 0.3;
+      this.opacity = Math.random() * 0.4 + 0.3;
+      this.baseX = this.x;
+      this.baseY = this.y;
+      this.color = Math.random() > 0.5 ? "212,175,55" : "255,107,53";
+    }
+
+    update() {
+      const dx = mouse.x - this.x;
+      const dy = mouse.y - this.y;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+
+      if (distance < 100) {
+        const force = (100 - distance) / 100;
+        const angle = Math.atan2(dy, dx);
+        this.x -= Math.cos(angle) * force * 3;
+        this.y -= Math.sin(angle) * force * 3;
+      } else {
+        this.x += (this.baseX - this.x) * 0.03;
+        this.y += (this.baseY - this.y) * 0.03;
+      }
+
+      this.baseX += this.speedX;
+      this.baseY += this.speedY;
+
+      if (this.baseX < 0 || this.baseX > canvas.width) {
+        this.speedX *= -1;
+      }
+      if (this.baseY < 0 || this.baseY > canvas.height) {
+        this.speedY *= -1;
+      }
+    }
+
+    draw() {
+      ctx.fillStyle = `rgba(${this.color},${this.opacity})`;
+      ctx.shadowBlur = 8;
+      ctx.shadowColor = `rgba(${this.color},0.8)`;
+      ctx.beginPath();
+      ctx.arc(this.x, this.y, this.size, 0, Math.PI * 2);
+      ctx.fill();
+    }
+  }
+
+  function animateParticles() {
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    particles.forEach((particle) => {
+      particle.update();
+      particle.draw();
+    });
+    window.requestAnimationFrame(animateParticles);
+  }
+
+  function initParticles() {
+    resizeCanvas();
+    particles = [];
+    const count = window.innerWidth < 768 ? 40 : 70;
+    for (let i = 0; i < count; i += 1) {
+      particles.push(new Particle());
+    }
+    animateParticles();
+  }
+
+  document.addEventListener(
+    "mousemove",
+    (event) => {
+      mouse.x = event.clientX;
+      mouse.y = event.clientY;
+    },
+    { passive: true },
+  );
+
+  window.addEventListener(
+    "resize",
+    () => {
+      resizeCanvas();
+      particles.forEach((particle) => particle.reset());
+    },
+    { passive: true },
+  );
+
+  window.initParticles = initParticles;
+})();

--- a/assets/js/core/sections.js
+++ b/assets/js/core/sections.js
@@ -1,0 +1,151 @@
+(() => {
+  const sections = Array.from(document.querySelectorAll("section"));
+  const scrollIndicators = Array.from(document.querySelectorAll(".scroll-indicator"));
+  const mainNav = document.getElementById("mainNav");
+  const heroSection = document.getElementById("hero");
+  const contactSection = document.getElementById("contact");
+  const footer = document.querySelector("footer");
+
+  let ticking = false;
+
+  function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+  }
+
+  function updateNavState() {
+    if (!mainNav) {
+      return;
+    }
+    if (window.scrollY > 80) {
+      mainNav.classList.add("scrolled");
+    } else {
+      mainNav.classList.remove("scrolled");
+    }
+  }
+
+  function computeProgress() {
+    const docHeight = Math.max(
+      document.documentElement ? document.documentElement.scrollHeight : 0,
+      document.body ? document.body.scrollHeight : 0,
+      window.innerHeight,
+      1,
+    );
+    const heroTop = heroSection ? heroSection.offsetTop : 0;
+    const contactBottom = contactSection
+      ? contactSection.offsetTop + contactSection.offsetHeight
+      : docHeight;
+    const footerBottom = footer
+      ? footer.offsetTop + footer.offsetHeight
+      : docHeight;
+    const rangeEnd = Math.max(contactBottom, footerBottom);
+    const range = Math.max(1, rangeEnd - heroTop);
+    const viewportCenter = window.scrollY + window.innerHeight * 0.5;
+    const rawProgress = (viewportCenter - heroTop) / range;
+    window.__towerScrollProgress = clamp(rawProgress, 0, 1);
+  }
+
+  function updateIndicators() {
+    scrollIndicators.forEach((indicator) => {
+      let section = indicator.closest("section");
+      if (!section) {
+        const sibling = indicator.previousElementSibling;
+        if (sibling && sibling.tagName === "SECTION") {
+          section = sibling;
+        }
+      }
+      const isActive = section ? section.classList.contains("visible") : false;
+      indicator.classList.toggle("is-visible", isActive);
+    });
+  }
+
+  function updateSections() {
+    const viewportHeight = window.innerHeight || 1;
+    sections.forEach((section) => {
+      const rect = section.getBoundingClientRect();
+      const visibleHeight = Math.max(
+        0,
+        Math.min(viewportHeight, rect.top + rect.height) - Math.max(0, rect.top),
+      );
+      const ratio = visibleHeight / viewportHeight;
+      if (ratio > 0.28) {
+        section.classList.add("visible");
+      } else {
+        section.classList.remove("visible");
+      }
+    });
+    updateIndicators();
+    computeProgress();
+  }
+
+  function requestUpdate() {
+    if (ticking) {
+      return;
+    }
+    ticking = true;
+    window.requestAnimationFrame(() => {
+      updateSections();
+      updateNavState();
+      ticking = false;
+    });
+  }
+
+  function handleResize() {
+    updateSections();
+    updateNavState();
+  }
+
+  function scrollToSection(id) {
+    const section = document.getElementById(id);
+    if (!section) {
+      return;
+    }
+    const navHeight = mainNav ? mainNav.getBoundingClientRect().height : 0;
+    const offset = section.getBoundingClientRect().top + window.pageYOffset - (navHeight + 40);
+    window.scrollTo({ top: offset, behavior: "smooth" });
+    if (typeof window.closeMobileMenu === "function") {
+      window.closeMobileMenu();
+    }
+  }
+
+  function carouselNext(id) {
+    const slider = document.getElementById(id);
+    if (!slider) {
+      return;
+    }
+    const card = slider.querySelector(
+      ".vault-card, .testimonial-card, .blog-card, .team-card",
+    );
+    if (card) {
+      slider.scrollBy({ left: card.offsetWidth + 32, behavior: "smooth" });
+    }
+  }
+
+  function carouselPrev(id) {
+    const slider = document.getElementById(id);
+    if (!slider) {
+      return;
+    }
+    const card = slider.querySelector(
+      ".vault-card, .testimonial-card, .blog-card, .team-card",
+    );
+    if (card) {
+      slider.scrollBy({ left: -(card.offsetWidth + 32), behavior: "smooth" });
+    }
+  }
+
+  function initSections() {
+    window.__towerScrollProgress = 0;
+    if (sections.length) {
+      sections[0].classList.add("visible");
+    }
+    updateSections();
+    updateNavState();
+    window.addEventListener("scroll", requestUpdate, { passive: true });
+    window.addEventListener("resize", handleResize, { passive: true });
+  }
+
+  window.initSections = initSections;
+  window.scrollToSection = scrollToSection;
+  window.carouselNext = carouselNext;
+  window.carouselPrev = carouselPrev;
+})();

--- a/assets/js/core/tower.js
+++ b/assets/js/core/tower.js
@@ -1,0 +1,894 @@
+let scene;
+let camera;
+let renderer;
+let towerGroup;
+let windowMeshes = [];
+const towerClock = new (window.THREE ? THREE.Clock : function () {})();
+let towerSections = [];
+const reusableVector = window.THREE ? new THREE.Vector3() : null;
+const towerParams = {
+  levels: 84,
+  baseWidth: 14.8,
+  topWidth: 5.6,
+  floorHeight: 1.85,
+};
+const lerp = (a, b, t) => a + (b - a) * t;
+function createCanvasTexture(drawFn) {
+  const size = 128,
+    canvas = document.createElement("canvas");
+  canvas.width = canvas.height = size;
+  const ctx = canvas.getContext("2d");
+  drawFn(ctx, size);
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+  return texture;
+}
+function createFacadeTexture() {
+  return createCanvasTexture((ctx, size) => {
+    const baseGradient = ctx.createLinearGradient(0, 0, size, size);
+    baseGradient.addColorStop(0, "#0f1724");
+    baseGradient.addColorStop(0.5, "#152233");
+    baseGradient.addColorStop(1, "#101a29");
+    ctx.fillStyle = baseGradient;
+    ctx.fillRect(0, 0, size, size);
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.06)";
+    for (let y = 0; y < size; y += 5) {
+      ctx.fillRect(0, y, size, 1);
+    }
+
+    ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
+    for (let x = 0; x < size; x += 7) {
+      ctx.fillRect(x, 0, 1, size);
+    }
+
+    ctx.strokeStyle = "rgba(255, 215, 0, 0.08)";
+    ctx.lineWidth = 0.6;
+    for (let d = -size; d < size; d += 12) {
+      ctx.beginPath();
+      ctx.moveTo(0, d + size * 0.25);
+      ctx.lineTo(size, d + size * 0.6);
+      ctx.stroke();
+    }
+
+    ctx.strokeStyle = "rgba(74, 155, 142, 0.08)";
+    ctx.lineWidth = 0.4;
+    for (let d = -size; d < size; d += 16) {
+      ctx.beginPath();
+      ctx.moveTo(size, d + size * 0.2);
+      ctx.lineTo(0, d + size * 0.65);
+      ctx.stroke();
+    }
+
+    ctx.globalAlpha = 0.07;
+    for (let i = 0; i < 120; i += 1) {
+      const w = 1;
+      const h = Math.random() * 6 + 2;
+      ctx.fillRect(Math.random() * size, Math.random() * size, w, h);
+    }
+    ctx.globalAlpha = 0.14;
+    for (let i = 0; i < 36; i += 1) {
+      const width = Math.random() * 4 + 2;
+      const height = Math.random() * 10 + 8;
+      const x = Math.random() * size;
+      const y = Math.random() * size;
+      const gradient = ctx.createLinearGradient(x, y, x + width, y + height);
+      gradient.addColorStop(0, "rgba(255, 183, 77, 0.25)");
+      gradient.addColorStop(1, "rgba(255, 255, 255, 0)");
+      ctx.fillStyle = gradient;
+      ctx.fillRect(x, y, width, height);
+    }
+    ctx.globalAlpha = 1;
+  });
+}
+function createMetalTexture() {
+  return createCanvasTexture((ctx, size) => {
+    const gradient = ctx.createLinearGradient(0, 0, size, size);
+    gradient.addColorStop(0, "#28394a");
+    gradient.addColorStop(0.5, "#1c2a39");
+    gradient.addColorStop(1, "#344b62");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, 0, size, size);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.12)";
+    ctx.fillRect(0, size * 0.45, size, size * 0.08);
+    ctx.fillStyle = "rgba(255, 255, 255, 0.08)";
+    ctx.fillRect(0, size * 0.7, size, size * 0.04);
+  });
+}
+function createNeonTexture() {
+  return createCanvasTexture((ctx, size) => {
+    ctx.fillStyle = "#000";
+    ctx.fillRect(0, 0, size, size);
+    ctx.strokeStyle = "rgba(255,215,0,0.4)";
+    ctx.lineWidth = 4;
+    ctx.strokeRect(8, 8, size - 16, size - 16);
+    ctx.strokeStyle = "rgba(255,107,53,0.45)";
+    ctx.lineWidth = 2;
+    ctx.strokeRect(20, 20, size - 40, size - 40);
+  });
+}
+function init3DScene() {
+  if (!window.THREE) return;
+  const tower3DContainer = document.getElementById("tower3DContainer");
+  if (!tower3DContainer) return;
+  tower3DContainer.innerHTML = "";
+  towerSections = Array.from(document.querySelectorAll("section"));
+  windowMeshes = [];
+  const sceneBackground = new THREE.Color(0x04070c);
+  scene = new THREE.Scene();
+  scene.fog = new THREE.Fog(sceneBackground, 90, 200);
+  camera = new THREE.PerspectiveCamera(
+    45,
+    window.innerWidth / window.innerHeight,
+    0.1,
+    1000,
+  );
+  camera.position.set(10, 68, 140);
+  renderer = new THREE.WebGLRenderer({ alpha: true, antialias: true });
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+  renderer.outputEncoding = THREE.sRGBEncoding;
+  renderer.shadowMap.enabled = false;
+  renderer.setClearColor(0x000000, 0);
+  tower3DContainer.appendChild(renderer.domElement);
+  const ambientLight = new THREE.AmbientLight(0x1f2a3a, 1.2);
+  scene.add(ambientLight);
+  const warmLight = new THREE.PointLight(0xffc277, 1.4, 160, 2);
+  warmLight.position.set(10, 28, 18);
+  scene.add(warmLight);
+  const coolLight = new THREE.PointLight(0x4a9b8e, 1, 140, 2);
+  coolLight.position.set(-12, 18, -16);
+  scene.add(coolLight);
+  const rimLight = new THREE.DirectionalLight(0xffffff, 0.6);
+  rimLight.position.set(0, 40, -40);
+  scene.add(rimLight);
+  towerGroup = new THREE.Group();
+  towerGroup.userData = { halo: null, orbiters: [], panels: [], pods: [] };
+  towerGroup.scale.setScalar(3.25);
+  towerGroup.position.y = 3;
+  scene.add(towerGroup);
+  const facadeTexture = createFacadeTexture();
+  facadeTexture.repeat.set(6.4, towerParams.levels * 1.05);
+  const metalTexture = createMetalTexture();
+  metalTexture.repeat.set(2, 6);
+  const neonTexture = createNeonTexture();
+  const mainMaterial = new THREE.MeshStandardMaterial({
+    map: facadeTexture,
+    color: 0x1b2737,
+    roughness: 0.32,
+    metalness: 0.65,
+    emissive: new THREE.Color(0x0a1420),
+    emissiveIntensity: 0.3,
+  });
+  const glassMaterial = new THREE.MeshStandardMaterial({
+    color: 0x223547,
+    roughness: 0.15,
+    metalness: 0.9,
+    transparent: true,
+    opacity: 0.45,
+    envMapIntensity: 1.4,
+  });
+  const detailMaterial = new THREE.MeshStandardMaterial({
+    map: metalTexture,
+    color: 0x253346,
+    roughness: 0.4,
+    metalness: 0.8,
+    emissive: new THREE.Color(0x1a2c3c),
+    emissiveIntensity: 0.25,
+  });
+  const { levels, baseWidth, topWidth, floorHeight } = towerParams;
+  const totalHeight = levels * floorHeight;
+  for (let level = 0; level < levels; level++) {
+    const t = level / levels;
+    const width = baseWidth - (baseWidth - topWidth) * Math.pow(t, 1.2);
+    const depth = width * 0.94;
+    const floorGeometry = new THREE.BoxGeometry(width, floorHeight, depth);
+    const floor = new THREE.Mesh(floorGeometry, mainMaterial.clone());
+    floor.material.map = facadeTexture.clone();
+    floor.material.map.offset.y = t * 2;
+    floor.position.y = level * floorHeight + floorHeight / 2;
+    towerGroup.add(floor);
+    const glassLayer = new THREE.Mesh(
+      new THREE.BoxGeometry(width * 0.92, floorHeight * 0.9, depth * 0.92),
+      glassMaterial.clone(),
+    );
+    glassLayer.position.y = floor.position.y;
+    towerGroup.add(glassLayer);
+    if (level % 4 === 0) {
+      const core = new THREE.Mesh(
+        new THREE.BoxGeometry(width * 0.62, floorHeight * 0.95, depth * 0.62),
+        detailMaterial.clone(),
+      );
+      core.position.y = floor.position.y;
+      towerGroup.add(core);
+    }
+    if (level % 3 === 0) {
+      const brace = new THREE.Mesh(
+        new THREE.BoxGeometry(width * 1.05, 0.12, depth * 1.05),
+        detailMaterial.clone(),
+      );
+      brace.position.y = level * floorHeight + floorHeight;
+      towerGroup.add(brace);
+    }
+  addWindowBand(width, depth, level * floorHeight + floorHeight / 2);
+  }
+  addVerticalFins(totalHeight, baseWidth, topWidth);
+  addBaseTerraces(baseWidth);
+  addLowerPlaza(baseWidth);
+  addSkyGardens(totalHeight, baseWidth);
+  addSkyBridges(totalHeight, baseWidth, topWidth);
+  addLightSpines(totalHeight);
+  addSkyDeck(totalHeight, topWidth);
+  addHelipad(totalHeight, topWidth);
+  addObservationPods(totalHeight, baseWidth);
+  addMediaPanels(baseWidth, totalHeight);
+  addAntennaArray(totalHeight, topWidth);
+  addSupportBeams(totalHeight, baseWidth, topWidth);
+
+  const crownMaterial = new THREE.MeshStandardMaterial({
+    map: neonTexture,
+    color: 0x2e3f55,
+    emissive: new THREE.Color(0xffc95b),
+    emissiveIntensity: 0.6,
+    transparent: true,
+    opacity: 0.9,
+    metalness: 0.7,
+    roughness: 0.2,
+  });
+  const crown = new THREE.Mesh(
+    new THREE.CylinderGeometry(topWidth * 1.4, topWidth * 1.8, 1.8, 32, 1, true),
+    crownMaterial,
+  );
+  crown.position.y = totalHeight + 1.1;
+  towerGroup.add(crown);
+  const spire = new THREE.Mesh(
+    new THREE.ConeGeometry(topWidth * 0.9, 4.5, 16),
+    new THREE.MeshStandardMaterial({
+      color: 0xffc95b,
+      emissive: 0xffe9a3,
+      emissiveIntensity: 1.1,
+      metalness: 0.9,
+      roughness: 0.15,
+    }),
+  );
+  spire.position.y = totalHeight + 4.2;
+  towerGroup.add(spire);
+  const halo = new THREE.Mesh(
+    new THREE.RingGeometry(1.2, 2.2, 64),
+    new THREE.MeshBasicMaterial({
+      color: 0xffe3a0,
+      transparent: true,
+      opacity: 0.35,
+      side: THREE.DoubleSide,
+      blending: THREE.AdditiveBlending,
+    }),
+  );
+  halo.rotation.x = Math.PI / 2;
+  halo.position.y = totalHeight + 2.6;
+  towerGroup.add(halo);
+  const aura = new THREE.Mesh(
+    new THREE.CylinderGeometry(baseWidth * 1.45, baseWidth * 1.8, 2.2, 48, 1, true),
+    new THREE.MeshBasicMaterial({
+      color: 0x4a9b8e,
+      transparent: true,
+      opacity: 0.18,
+      blending: THREE.AdditiveBlending,
+      side: THREE.DoubleSide,
+    }),
+  );
+  aura.position.y = 1.2;
+  towerGroup.add(aura);
+  const podium = new THREE.Mesh(
+    new THREE.CylinderGeometry(baseWidth * 1.8, baseWidth * 2.4, 1.4, 48),
+    new THREE.MeshStandardMaterial({
+      color: 0x101a28,
+      metalness: 0.5,
+      roughness: 0.8,
+    }),
+  );
+  podium.position.y = -0.7;
+  towerGroup.add(podium);
+  const orbiters = createOrbitingLights(totalHeight);
+  orbiters.forEach((orb) => towerGroup.add(orb.mesh));
+  towerGroup.userData.halo = halo;
+  towerGroup.userData.orbiters = orbiters;
+  animate3D();
+}
+function addWindowBand(width, depth, y) {
+  const windowMaterialBase = new THREE.MeshStandardMaterial({
+    color: 0xfff4c2,
+    emissive: 0xfff4c2,
+    emissiveIntensity: 0.6,
+    metalness: 0.1,
+    roughness: 0.2,
+    transparent: true,
+    opacity: 0.85,
+    blending: THREE.AdditiveBlending,
+  });
+  const windowGeometry = new THREE.PlaneGeometry(width * 0.14, 0.58);
+  const sides = [
+    { axis: "z", sign: depth / 2 + 0.001, rotation: 0 },
+    { axis: "x", sign: width / 2 + 0.001, rotation: Math.PI / 2 },
+    { axis: "z", sign: -depth / 2 - 0.001, rotation: Math.PI },
+    { axis: "x", sign: -width / 2 - 0.001, rotation: -Math.PI / 2 },
+  ];
+  sides.forEach((side, sideIndex) => {
+    const columns = side.axis === "z" ? 4 : 5;
+    for (let i = 0; i < columns; i++) {
+      const mesh = new THREE.Mesh(windowGeometry, windowMaterialBase.clone());
+      const offset = (i - (columns - 1) / 2) * (side.axis === "z" ? width * 0.24 : depth * 0.32);
+      mesh.position.y = y;
+      if (side.axis === "z") {
+        mesh.position.x = offset;
+        mesh.position.z = side.sign;
+      } else {
+        mesh.position.z = offset;
+        mesh.position.x = side.sign;
+      }
+      mesh.rotation.y = side.rotation;
+      mesh.material.emissiveIntensity = 0.65 + Math.random() * 0.25;
+      mesh.material.opacity = 0.55 + Math.random() * 0.3;
+      towerGroup.add(mesh);
+      windowMeshes.push({
+        mesh,
+        speed: 0.45 + Math.random() * 0.85,
+        phase: Math.random() * Math.PI * 2,
+        amplitude: 0.4 + Math.random() * 0.35,
+        baseIntensity: 0.6 + Math.random() * 0.25,
+      });
+    }
+  });
+}
+function createOrbitingLights(totalHeight) {
+  const orbiters = [];
+  const colors = [0xffb347, 0x4a9b8e, 0xffe177];
+  for (let i = 0; i < 3; i++) {
+    const sphere = new THREE.Mesh(
+      new THREE.SphereGeometry(0.22, 16, 16),
+      new THREE.MeshBasicMaterial({
+        color: colors[i],
+        transparent: true,
+        opacity: 0.85,
+        blending: THREE.AdditiveBlending,
+      }),
+    );
+    sphere.position.y = totalHeight * (0.25 + 0.25 * i);
+    orbiters.push({
+      mesh: sphere,
+      radius: 4.5 + i * 1.2,
+      speed: 0.3 + i * 0.12,
+      offset: Math.random() * Math.PI * 2,
+    });
+  }
+  return orbiters;
+}
+function addVerticalFins(totalHeight, baseWidth, topWidth) {
+  const finMaterial = new THREE.MeshStandardMaterial({
+    color: 0x182230,
+    emissive: 0x1f2e42,
+    emissiveIntensity: 0.18,
+    metalness: 0.85,
+    roughness: 0.35,
+    transparent: true,
+    opacity: 0.85,
+  });
+  for (let i = 0; i < 4; i += 1) {
+    const ratio = 0.6 + i * 0.1;
+    const fin = new THREE.Mesh(
+      new THREE.BoxGeometry(baseWidth * ratio * 0.14, totalHeight + 4, 0.12),
+      finMaterial.clone(),
+    );
+    const angle = (Math.PI / 2) * i;
+    const radiusBase = (baseWidth + topWidth) * 0.4;
+    const radius = radiusBase + i * baseWidth * 0.06;
+    fin.position.set(Math.cos(angle) * radius, totalHeight / 2, Math.sin(angle) * radius);
+    fin.rotation.y = angle;
+    towerGroup.add(fin);
+  }
+
+  const latticeMaterial = new THREE.MeshStandardMaterial({
+    color: 0x1f2b3a,
+    emissive: 0x2e4b61,
+    emissiveIntensity: 0.12,
+    metalness: 0.7,
+    roughness: 0.4,
+    transparent: true,
+    opacity: 0.7,
+  });
+  for (let tier = 0; tier < 3; tier += 1) {
+    const lattice = new THREE.Mesh(
+      new THREE.CylinderGeometry(
+        (baseWidth * (0.95 - tier * 0.18) + topWidth * 0.5) / 1.0,
+        (baseWidth * (0.9 - tier * 0.18) + topWidth * 0.45) / 1.0,
+        0.2,
+        48,
+        1,
+        true,
+      ),
+      latticeMaterial.clone(),
+    );
+    lattice.position.y = totalHeight * (0.32 + tier * 0.2);
+    towerGroup.add(lattice);
+  }
+}
+
+function addSupportBeams(totalHeight, baseWidth, topWidth) {
+  const beamMaterial = new THREE.MeshStandardMaterial({
+    color: 0x141f2c,
+    metalness: 0.78,
+    roughness: 0.42,
+    emissive: new THREE.Color(0x213349),
+    emissiveIntensity: 0.22,
+  });
+  const offsets = [
+    [1, 1],
+    [-1, 1],
+    [1, -1],
+    [-1, -1],
+  ];
+  offsets.forEach(([xSign, zSign]) => {
+    const beam = new THREE.Mesh(
+      new THREE.BoxGeometry(baseWidth * 0.24, totalHeight + 6.5, baseWidth * 0.24),
+      beamMaterial.clone(),
+    );
+    const x = (baseWidth * 0.58) * xSign;
+    const z = (baseWidth * 0.42) * zSign;
+    beam.position.set(x, totalHeight / 2, z);
+    towerGroup.add(beam);
+  });
+
+  const ringMaterial = new THREE.MeshStandardMaterial({
+    color: 0x1d2a3c,
+    metalness: 0.65,
+    roughness: 0.45,
+    transparent: true,
+    opacity: 0.55,
+  });
+  for (let level = 1; level <= 6; level += 1) {
+    const radius = baseWidth * (0.78 + level * 0.04);
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(radius, topWidth * 0.12, 18, 64),
+      ringMaterial.clone(),
+    );
+    ring.rotation.x = Math.PI / 2;
+    ring.position.y = (totalHeight / 7) * level;
+    towerGroup.add(ring);
+  }
+}
+function addBaseTerraces(baseWidth) {
+  const terraceMaterial = new THREE.MeshStandardMaterial({
+    color: 0x0d1622,
+    metalness: 0.55,
+    roughness: 0.8,
+  });
+  for (let i = 0; i < 3; i += 1) {
+    const terrace = new THREE.Mesh(
+      new THREE.CylinderGeometry(
+        baseWidth * (1.8 + i * 0.25),
+        baseWidth * (2.1 + i * 0.25),
+        0.4,
+        48,
+      ),
+      terraceMaterial,
+    );
+    terrace.position.y = -1.2 - i * 0.45;
+    towerGroup.add(terrace);
+  }
+}
+
+function addLowerPlaza(baseWidth) {
+  const plaza = new THREE.Mesh(
+    new THREE.CylinderGeometry(baseWidth * 2.6, baseWidth * 2.6, 0.2, 64),
+    new THREE.MeshStandardMaterial({
+      color: 0x0b111a,
+      metalness: 0.3,
+      roughness: 0.85,
+      emissive: 0x172434,
+      emissiveIntensity: 0.12,
+    }),
+  );
+  plaza.position.y = -2.2;
+  towerGroup.add(plaza);
+}
+
+function addSkyGardens(totalHeight, baseWidth) {
+  const ringMaterial = new THREE.MeshStandardMaterial({
+    color: 0x1a3a2f,
+    metalness: 0.4,
+    roughness: 0.65,
+    emissive: 0x245846,
+    emissiveIntensity: 0.25,
+  });
+  for (let i = 0; i < 3; i += 1) {
+    const height = totalHeight * (0.35 + i * 0.18);
+    const ring = new THREE.Mesh(
+      new THREE.TorusGeometry(baseWidth * (1.1 - i * 0.12), 0.12, 24, 96),
+      ringMaterial.clone(),
+    );
+    ring.rotation.x = Math.PI / 2;
+    ring.position.y = height;
+    towerGroup.add(ring);
+
+    const foliage = new THREE.Mesh(
+      new THREE.TorusGeometry(baseWidth * (1.08 - i * 0.12), 0.18, 16, 48),
+      new THREE.MeshLambertMaterial({
+        color: 0x1f6d4a,
+        emissive: 0x1d8f5f,
+        emissiveIntensity: 0.15,
+      }),
+    );
+    foliage.rotation.x = Math.PI / 2;
+    foliage.position.y = height + 0.12;
+    towerGroup.add(foliage);
+  }
+}
+
+function addSkyBridges(totalHeight, baseWidth, topWidth) {
+  const torusMaterialBase = new THREE.MeshStandardMaterial({
+    color: 0x1d2a39,
+    metalness: 0.85,
+    roughness: 0.32,
+    emissive: new THREE.Color(0x30445c),
+    emissiveIntensity: 0.22,
+  });
+  const glowMaterialBase = new THREE.MeshBasicMaterial({
+    color: 0xffd27f,
+    transparent: true,
+    opacity: 0.24,
+    blending: THREE.AdditiveBlending,
+  });
+  const tiers = [0.28, 0.46, 0.64, 0.82];
+  tiers.forEach((ratio, index) => {
+    const height = totalHeight * ratio + 1.2 + index * 0.3;
+    const radius = (baseWidth + topWidth) * (0.6 + index * 0.09);
+    const walkway = new THREE.Mesh(
+      new THREE.TorusGeometry(radius, 0.14 + index * 0.03, 24, 72),
+      torusMaterialBase.clone(),
+    );
+    walkway.material.emissiveIntensity += index * 0.05;
+    walkway.rotation.x = Math.PI / 2;
+    walkway.position.y = height;
+    towerGroup.add(walkway);
+
+    const glow = new THREE.Mesh(
+      new THREE.TorusGeometry(radius + 0.35, 0.05, 16, 96),
+      glowMaterialBase.clone(),
+    );
+    glow.rotation.x = Math.PI / 2;
+    glow.position.y = height + 0.12;
+    glow.material.opacity = 0.2 + index * 0.04;
+    towerGroup.add(glow);
+
+    const strutMaterial = new THREE.MeshStandardMaterial({
+      color: 0x243344,
+      metalness: 0.82,
+      roughness: 0.38,
+      emissive: new THREE.Color(0x32485e),
+      emissiveIntensity: 0.18,
+    });
+    for (let i = 0; i < 6; i += 1) {
+      const angle = (Math.PI * 2 * i) / 6;
+      const strut = new THREE.Mesh(
+        new THREE.CylinderGeometry(0.06, 0.06, totalHeight * 0.08, 12, 1, true),
+        strutMaterial.clone(),
+      );
+      strut.position.set(
+        Math.cos(angle) * radius,
+        height,
+        Math.sin(angle) * radius,
+      );
+      strut.rotation.z = Math.PI / 2;
+      strut.rotation.y = angle;
+      towerGroup.add(strut);
+    }
+  });
+}
+
+function addLightSpines(totalHeight) {
+  const spineMaterial = new THREE.MeshBasicMaterial({
+    color: 0xffd27f,
+    transparent: true,
+    opacity: 0.4,
+    blending: THREE.AdditiveBlending,
+  });
+  for (let i = 0; i < 6; i += 1) {
+    const spine = new THREE.Mesh(
+      new THREE.BoxGeometry(0.12, totalHeight + 5, 0.12),
+      spineMaterial.clone(),
+    );
+    const angle = (Math.PI / 3) * i;
+    const radius = 1.6 + Math.sin(i * 1.2) * 0.3;
+    spine.position.set(Math.cos(angle) * radius, totalHeight / 2, Math.sin(angle) * radius);
+    towerGroup.add(spine);
+  }
+}
+function addSkyDeck(totalHeight, topWidth) {
+  const deckMaterial = new THREE.MeshStandardMaterial({
+    color: 0x23364d,
+    metalness: 0.65,
+    roughness: 0.35,
+    emissive: 0x3f6c7a,
+    emissiveIntensity: 0.25,
+  });
+  const deck = new THREE.Mesh(
+    new THREE.RingGeometry(topWidth * 1.4, topWidth * 2.1, 64, 1),
+    deckMaterial,
+  );
+  deck.rotation.x = Math.PI / 2;
+  deck.position.y = totalHeight + 0.6;
+  towerGroup.add(deck);
+
+  const lightMaterial = new THREE.MeshBasicMaterial({
+    color: 0xffd27f,
+    transparent: true,
+    opacity: 0.4,
+    blending: THREE.AdditiveBlending,
+    side: THREE.DoubleSide,
+  });
+  const lightRing = new THREE.Mesh(
+    new THREE.RingGeometry(topWidth * 1.55, topWidth * 1.75, 64, 1),
+    lightMaterial,
+  );
+  lightRing.rotation.x = Math.PI / 2;
+  lightRing.position.y = deck.position.y + 0.15;
+  towerGroup.add(lightRing);
+}
+
+function addHelipad(totalHeight, topWidth) {
+  const pad = new THREE.Mesh(
+    new THREE.CircleGeometry(topWidth * 1.45, 48),
+    new THREE.MeshStandardMaterial({
+      color: 0x0e1723,
+      roughness: 0.6,
+      metalness: 0.35,
+    }),
+  );
+  pad.rotation.x = -Math.PI / 2;
+  pad.position.y = totalHeight + 1.4;
+  towerGroup.add(pad);
+
+  const hMaterial = new THREE.MeshBasicMaterial({
+    color: 0xffd27f,
+    transparent: true,
+    opacity: 0.7,
+    side: THREE.DoubleSide,
+  });
+  const hShape = new THREE.Shape();
+  const size = topWidth * 0.75;
+  const thickness = size * 0.18;
+  hShape.moveTo(-size / 2, -size);
+  hShape.lineTo(-size / 2 + thickness, -size);
+  hShape.lineTo(-size / 2 + thickness, -thickness);
+  hShape.lineTo(size / 2 - thickness, -thickness);
+  hShape.lineTo(size / 2 - thickness, -size);
+  hShape.lineTo(size / 2, -size);
+  hShape.lineTo(size / 2, size);
+  hShape.lineTo(size / 2 - thickness, size);
+  hShape.lineTo(size / 2 - thickness, thickness);
+  hShape.lineTo(-size / 2 + thickness, thickness);
+  hShape.lineTo(-size / 2 + thickness, size);
+  hShape.lineTo(-size / 2, size);
+  const hGeometry = new THREE.ShapeGeometry(hShape);
+  const helipad = new THREE.Mesh(hGeometry, hMaterial);
+  helipad.rotation.x = -Math.PI / 2;
+  helipad.position.y = pad.position.y + 0.02;
+  towerGroup.add(helipad);
+}
+
+function addObservationPods(totalHeight, baseWidth) {
+  const podBodyMaterial = new THREE.MeshStandardMaterial({
+    color: 0x1a2736,
+    roughness: 0.4,
+    metalness: 0.8,
+    emissive: new THREE.Color(0x142433),
+    emissiveIntensity: 0.35,
+  });
+  const podGlassMaterial = new THREE.MeshStandardMaterial({
+    color: 0x3a6c88,
+    transparent: true,
+    opacity: 0.6,
+    roughness: 0.2,
+    metalness: 0.5,
+    emissive: new THREE.Color(0x54a7c7),
+    emissiveIntensity: 0.4,
+  });
+  const radii = [baseWidth * 1.65, baseWidth * 1.45, baseWidth * 1.25];
+  const heights = [totalHeight * 0.32, totalHeight * 0.54, totalHeight * 0.74];
+  heights.forEach((height, index) => {
+    const radius = radii[index];
+    for (let i = 0; i < 4; i += 1) {
+      const angle = (i / 4) * Math.PI * 2 + index * 0.4;
+      const podGroup = new THREE.Group();
+      const body = new THREE.Mesh(
+        new THREE.CylinderGeometry(baseWidth * 0.18, baseWidth * 0.22, 1.6, 24, 1, true),
+        podBodyMaterial.clone(),
+      );
+      body.rotation.z = Math.PI / 2;
+      body.rotation.y = Math.PI / 2;
+      body.position.set(0, 0, 0);
+      podGroup.add(body);
+      const glass = new THREE.Mesh(
+        new THREE.SphereGeometry(baseWidth * 0.28, 24, 16, 0, Math.PI),
+        podGlassMaterial.clone(),
+      );
+      glass.rotation.x = Math.PI / 2;
+      glass.position.set(baseWidth * 0.22, 0, 0);
+      podGroup.add(glass);
+      podGroup.position.set(Math.cos(angle) * radius, height, Math.sin(angle) * radius);
+      podGroup.lookAt(0, height, 0);
+      podGroup.userData = { radius, baseHeight: height, angleOffset: angle };
+      towerGroup.add(podGroup);
+      if (towerGroup.userData && Array.isArray(towerGroup.userData.pods)) {
+        towerGroup.userData.pods.push(podGroup);
+      }
+    }
+  });
+}
+
+function createBillboardTexture() {
+  return createCanvasTexture((ctx, size) => {
+    ctx.fillStyle = "#04070c";
+    ctx.fillRect(0, 0, size, size);
+    const gradient = ctx.createLinearGradient(0, 0, size, size);
+    gradient.addColorStop(0, "rgba(255, 140, 0, 0.5)");
+    gradient.addColorStop(0.5, "rgba(74, 155, 142, 0.4)");
+    gradient.addColorStop(1, "rgba(255, 215, 0, 0.35)");
+    ctx.fillStyle = gradient;
+    ctx.fillRect(0, size * 0.1, size, size * 0.8);
+    ctx.globalAlpha = 0.6;
+    ctx.fillStyle = "rgba(0, 0, 0, 0.35)";
+    for (let i = 0; i < 8; i += 1) {
+      const y = size * (0.18 + 0.08 * i);
+      ctx.fillRect(size * 0.1, y, size * 0.8, size * 0.015);
+    }
+    ctx.globalAlpha = 1;
+  });
+}
+
+function addMediaPanels(baseWidth, totalHeight) {
+  const panelTexture = createBillboardTexture();
+  const panelMaterial = new THREE.MeshBasicMaterial({
+    map: panelTexture,
+    transparent: true,
+    opacity: 0.85,
+    side: THREE.DoubleSide,
+  });
+  const panelGeometry = new THREE.PlaneGeometry(baseWidth * 1.9, baseWidth * 0.7);
+  const heights = [totalHeight * 0.12, totalHeight * 0.22];
+  heights.forEach((height, index) => {
+    const count = 3 + index;
+    for (let i = 0; i < count; i += 1) {
+      const angle = (i / count) * Math.PI * 2 + index * 0.3;
+      const radius = baseWidth * 1.4;
+      const panel = new THREE.Mesh(panelGeometry, panelMaterial.clone());
+      panel.position.set(Math.cos(angle) * radius, height, Math.sin(angle) * radius);
+      panel.lookAt(0, height, 0);
+      panel.userData = { angleOffset: angle, radius, height };
+      towerGroup.add(panel);
+      if (towerGroup.userData && Array.isArray(towerGroup.userData.panels)) {
+        towerGroup.userData.panels.push(panel);
+      }
+    }
+  });
+}
+
+function addAntennaArray(totalHeight, topWidth) {
+  const mastMaterial = new THREE.MeshStandardMaterial({
+    color: 0xd4af37,
+    roughness: 0.2,
+    metalness: 0.9,
+    emissive: new THREE.Color(0xffe7a3),
+    emissiveIntensity: 0.7,
+  });
+  const mast = new THREE.Mesh(new THREE.CylinderGeometry(topWidth * 0.08, topWidth * 0.12, 5, 32), mastMaterial);
+  mast.position.y = totalHeight + 3.2;
+  towerGroup.add(mast);
+
+  const beaconMaterial = new THREE.MeshBasicMaterial({
+    color: 0xfff1b0,
+    transparent: true,
+    opacity: 0.9,
+    blending: THREE.AdditiveBlending,
+  });
+  const beacon = new THREE.Mesh(new THREE.SphereGeometry(topWidth * 0.25, 24, 18), beaconMaterial);
+  beacon.position.y = mast.position.y + 2.6;
+  towerGroup.add(beacon);
+}
+function animate3D() {
+  requestAnimationFrame(animate3D);
+  const elapsed = towerClock.getElapsedTime ? towerClock.getElapsedTime() : 0;
+  const scrollY = window.scrollY;
+  const maxScroll = Math.max(
+    1,
+    document.documentElement.scrollHeight - window.innerHeight,
+  );
+  const scrollProgress =
+    typeof window.__towerScrollProgress === "number"
+      ? window.__towerScrollProgress
+      : Math.min(scrollY / maxScroll, 1);
+  const easedProgress = Math.pow(scrollProgress, 0.92);
+  const totalHeight = towerParams.levels * towerParams.floorHeight;
+  const scaleFactor = towerGroup ? towerGroup.scale.y : 1;
+  const scaledHeight = totalHeight * scaleFactor;
+  const focusY = lerp(scaledHeight * 0.35, scaledHeight + 48, easedProgress);
+  const targetX = lerp(10, 2.5, easedProgress);
+  const targetY = lerp(72, scaledHeight + 128, easedProgress);
+  const targetZ = lerp(140, 78, easedProgress);
+  if (reusableVector) {
+    reusableVector.set(targetX, targetY, targetZ);
+    camera.position.lerp(reusableVector, 0.08);
+  } else {
+    camera.position.lerp(new THREE.Vector3(targetX, targetY, targetZ), 0.08);
+  }
+  camera.lookAt(0, focusY, 0);
+  if (towerGroup) {
+    const rotationTarget = lerp(0.18, 0.06, easedProgress);
+    towerGroup.rotation.y += (rotationTarget - towerGroup.rotation.y) * 0.08;
+    towerGroup.position.y = lerp(3, 6, easedProgress);
+  }
+  const desiredFov = lerp(44, 32, easedProgress);
+  if (typeof camera.fov === "number") {
+    camera.fov += (desiredFov - camera.fov) * 0.08;
+    camera.updateProjectionMatrix();
+  }
+  const { halo, orbiters, panels = [], pods = [] } = towerGroup.userData || {};
+  if (halo) {
+    halo.rotation.z = 0;
+    halo.material.opacity = 0.28 + easedProgress * 0.32;
+  }
+  if (orbiters) {
+    orbiters.forEach((orbiter) => {
+      const baseAngle = orbiter.offset || 0;
+      const radius = orbiter.radius || 5;
+      const baseHeight = totalHeight * (0.22 + orbiter.radius * 0.01);
+      orbiter.mesh.position.x = Math.cos(baseAngle) * radius;
+      orbiter.mesh.position.z = Math.sin(baseAngle) * radius;
+      orbiter.mesh.position.y = baseHeight;
+    });
+  }
+  panels.forEach((panel) => {
+    const data = panel.userData || {};
+    const baseAngle = data.angleOffset || 0;
+    const radius = data.radius || 1;
+    const height = data.height || panel.position.y;
+    panel.position.x = Math.cos(baseAngle) * radius;
+    panel.position.z = Math.sin(baseAngle) * radius;
+    panel.position.y = height;
+    if (reusableVector) {
+      reusableVector.set(0, height, 0);
+      panel.lookAt(reusableVector);
+    } else {
+      panel.lookAt(new THREE.Vector3(0, height, 0));
+    }
+  });
+  pods.forEach((pod) => {
+    const data = pod.userData || {};
+    const radius = data.radius || 1;
+    const baseHeight = data.baseHeight || pod.position.y;
+    const baseAngle = data.angleOffset || 0;
+    pod.position.x = Math.cos(baseAngle) * radius;
+    pod.position.y = baseHeight;
+    pod.position.z = Math.sin(baseAngle) * radius;
+    pod.lookAt(0, baseHeight, 0);
+  });
+  windowMeshes.forEach((data) => {
+    const intensity =
+      data.baseIntensity +
+      data.amplitude * Math.sin(elapsed * data.speed + data.phase + easedProgress * 6.2);
+    data.mesh.material.emissiveIntensity = intensity;
+    data.mesh.material.opacity =
+      0.55 +
+      0.25 *
+        Math.sin(elapsed * data.speed * 1.4 + data.phase * 1.3 + easedProgress * 4.5);
+  });
+  renderer.render(scene, camera);
+}
+window.addEventListener("resize", () => {
+  if (!camera || !renderer) return;
+  camera.aspect = window.innerWidth / window.innerHeight;
+  camera.updateProjectionMatrix();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+});
+
+window.init3DScene = init3DScene;

--- a/digital-tower-optimized(1).html
+++ b/digital-tower-optimized(1).html
@@ -1,1781 +1,1236 @@
-<!DOCTYPE html><html lang="it"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"><meta name="description" content="Digital Tower - Agenzia digitale di marketing e comunicazione a Napoli. Trasformiamo la tua visione in successo digitale attraverso web design innovativo, branding distintivo, contenuti coinvolgenti e strategie di marketing data-driven che generano risultati concreti e misurabili."><meta name="keywords" content="web design Napoli, agenzia digitale Napoli, branding Napoli, marketing digitale, sviluppo web, SEO Italia, social media marketing, content marketing, web agency Napoli, digital marketing Italia"><meta name="theme-color" content="#d4af37"><meta property="og:title" content="Digital Tower - Trasforma la Tua Visione in Successo Digitale"><meta property="og:description" content="Agenzia digitale specializzata in web design, branding e strategie digitali che generano risultati concreti"><meta property="og:type" content="website"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;800;900&display=swap" rel="stylesheet"><script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" defer></script><title>Digital Tower - Scaliamo Insieme la Torre del Successo</title><style>
-    :root{--black:#0a0e14;--dark-teal:#0d1b2a;--gold:#d4af37;--gold-light:#ffd700;--gold-dark:#9a7c1f;--amber:#ffbf00;--orange:#ff6b35;--teal:#4a9b8e;--cyan:#64dfdf;--white:#e8eaed;--white-dim:#94a3b8;--left:clamp(24px,8vw,120px)}
-    *{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent}
-    html{scroll-behavior:smooth;overflow-x:hidden}
-    body{font-family:Montserrat,sans-serif;background:#000;color:var(--white);overflow-x:hidden;cursor:none;-webkit-font-smoothing:antialiased}
-    @media(max-width:1024px){body{cursor:auto}}
-    .loader{position:fixed;inset:0;background:radial-gradient(ellipse at 50% 20%,rgba(255,183,0,.08),transparent 60%),radial-gradient(ellipse at 50% 80%,rgba(255,107,53,.06),transparent 70%),#0a0e14;display:flex;flex-direction:column;align-items:center;justify-content:center;z-index:10000;transition:opacity .8s,visibility .8s}
-    .loader.hidden{opacity:0;visibility:hidden;pointer-events:none}
-    .loader-tower{width:min(200px,40vw);height:auto;margin-bottom:2rem;filter:drop-shadow(0 10px 30px rgba(212,175,55,.3))}
-    .loader-tower path,.loader-tower rect,.loader-tower polygon{stroke-dasharray:var(--len);stroke-dashoffset:var(--len);animation:drawPath 2s ease-out forwards}
-    @keyframes drawPath{to{stroke-dashoffset:0}}
-    .loader-text{font-size:clamp(1rem,3vw,1.5rem);font-weight:800;letter-spacing:.25em;color:var(--gold);margin-bottom:2rem;text-transform:uppercase;text-shadow:0 0 20px rgba(212,175,55,.5)}
-    .loader-text span{display:inline-block;opacity:0;animation:fadeIn .5s forwards;animation-delay:calc(var(--i) * .05s)}
-    @keyframes fadeIn{to{opacity:1}}
-    .loader-bar-wrap{width:min(350px,80vw);height:4px;background:rgba(212,175,55,.15);border-radius:4px;overflow:hidden}
-    .loader-bar{height:100%;background:linear-gradient(90deg,#9a7c1f,#d4af37,#ffbf00,#ffd700);width:0;transition:width .3s;box-shadow:0 0 20px rgba(212,175,55,.8)}
-    .carbon-fiber{position:fixed;top:0;left:0;width:100%;height:100%;z-index:0;opacity:.12;background-image:repeating-linear-gradient(0deg,transparent,transparent 2px,rgba(74,155,142,.2)2px,rgba(74,155,142,.2)4px),repeating-linear-gradient(90deg,transparent,transparent 2px,rgba(255,107,53,.12)2px,rgba(255,107,53,.12)4px);background-size:6px 6px;pointer-events:none}
-    .vignette{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:3;background:radial-gradient(ellipse at center,transparent 15%,rgba(10,14,20,.85)85%)}
-    .cursor,.cursor-follower{border-radius:50%;position:fixed;pointer-events:none;z-index:9999;mix-blend-mode:difference;will-change:transform;top:-50px;left:-50px}
-    .cursor{width:12px;height:12px;border:2px solid var(--gold);transition:transform .15s;box-shadow:0 0 10px rgba(212,175,55,.6)}
-    .cursor-follower{width:50px;height:50px;border:1px solid rgba(212,175,55,.4);z-index:9998;transition:transform .3s}
-    nav{position:fixed;top:0;left:0;width:100%;padding:1.5rem 5%;display:flex;justify-content:space-between;align-items:center;z-index:1000;opacity:0;transition:opacity 2s ease 2s,background .3s;backdrop-filter:blur(20px);border-bottom:1px solid rgba(74,155,142,.15)}
-    nav.visible{opacity:1}
-    nav.scrolled{background:rgba(10,14,20,.85);box-shadow:0 4px 30px rgba(0,0,0,.9),0 0 15px rgba(255,107,53,.1)}
-    .nav-logo{font-size:1.5rem;font-weight:900;letter-spacing:.1em;background:linear-gradient(135deg,#ffd700,#ff6b35,#d4af37);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;cursor:pointer;transition:all .3s;filter:drop-shadow(0 0 10px rgba(212,175,55,.3))}
-    .nav-logo:hover{transform:scale(1.05);filter:drop-shadow(0 0 15px rgba(255,107,53,.6))}
-    .nav-menu{display:flex;gap:2rem;list-style:none;align-items:center}
-    .nav-menu>li{position:relative}
-    .nav-menu a{color:var(--white-dim);text-decoration:none;font-size:.8rem;text-transform:uppercase;letter-spacing:.15em;font-weight:600;transition:all .3s;padding:.5rem 0;display:block;position:relative}
-    .nav-menu a::after{content:'';position:absolute;bottom:0;left:0;width:0;height:2px;background:linear-gradient(90deg,var(--orange),var(--gold));transition:width .3s}
-    .nav-menu a:hover{color:var(--gold)}
-    .nav-menu a:hover::after{width:100%}
-    .nav-cta{background:linear-gradient(135deg,#ff6b35,#ffbf00)!important;color:#000!important;padding:.8rem 1.8rem!important;border-radius:4px;font-weight:800;position:relative;overflow:hidden}
-    .nav-cta::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,#ff6b35,#ffbf00);opacity:.6;filter:blur(15px);z-index:-1;animation:ctaPulse 2s ease-in-out infinite}
-    @keyframes ctaPulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.1);opacity:.8}}
-    .nav-cta::after{display:none}
-    .nav-dropdown{position:relative}
-    .nav-dropdown>a{display:flex;align-items:center;gap:.5rem}
-    .nav-dropdown>a::before{content:'▸';font-size:.9rem;transition:transform .3s}
-    .nav-dropdown:hover>a::before{transform:rotate(90deg)}
-    .nav-dropdown-menu{position:absolute;top:100%;left:0;background:rgba(10,14,20,.98);backdrop-filter:blur(20px);border:1px solid rgba(74,155,142,.3);border-radius:8px;padding:1rem 0;min-width:200px;opacity:0;visibility:hidden;transform:translateY(-10px);transition:all .3s;box-shadow:0 10px 40px rgba(0,0,0,.7),0 0 15px rgba(255,107,53,.15);list-style:none}
-    .nav-dropdown:hover .nav-dropdown-menu{opacity:1;visibility:visible;transform:translateY(0)}
-    .nav-dropdown-menu a{padding:.8rem 1.5rem;font-size:.75rem}
-    .nav-dropdown-menu a:hover{background:rgba(255,107,53,.1)}
-    .hamburger{display:flex;flex-direction:column;gap:5px;cursor:pointer;z-index:1001;width:30px;height:25px;position:relative;transition:transform .4s}
-    .hamburger span{width:100%;height:2px;background:var(--gold);transition:all .4s;border-radius:2px;transform-origin:center;box-shadow:0 0 5px rgba(212,175,55,.4)}
-    .hamburger.active{transform:rotate(180deg)}
-    .hamburger.active span:nth-child(1){transform:rotate(45deg)translate(5px,5px)}
-    .hamburger.active span:nth-child(2){opacity:0;transform:translateX(-10px)}
-    .hamburger.active span:nth-child(3){transform:rotate(-45deg)translate(7px,-6px)}
-    .mobile-menu{position:fixed;top:0;right:-100%;width:100%;max-width:400px;height:100vh;background:linear-gradient(135deg,rgba(10,14,20,.98),rgba(13,27,42,.98));backdrop-filter:blur(30px);z-index:999;padding:6rem 2rem 2rem;transition:right .5s;overflow-y:auto;box-shadow:-5px 0 30px rgba(0,0,0,.7);border-left:1px solid rgba(74,155,142,.3)}
-    .mobile-menu.active{right:0}
-    .mobile-menu-links{list-style:none;margin-bottom:2rem}
-    .mobile-menu-links>li{margin-bottom:.5rem}
-    .mobile-menu-links a{color:var(--white);text-decoration:none;font-size:1.1rem;text-transform:uppercase;letter-spacing:.15em;font-weight:600;padding:1rem;display:block;border-left:3px solid transparent;transition:all .3s;position:relative;font-family:Montserrat,sans-serif}
-    .mobile-menu-links a::before{content:'';position:absolute;left:0;top:0;width:0;height:100%;background:rgba(255,107,53,.08);transition:width .3s;z-index:-1}
-    .mobile-menu-links a:hover{color:var(--gold);border-left-color:var(--orange)}
-    .mobile-menu-links a:hover::before{width:100%}
-    .mobile-submenu{padding-left:1rem;max-height:0;overflow:hidden;transition:max-height .3s}
-    .mobile-submenu.active{max-height:300px}
-    .mobile-submenu a{font-size:.95rem;padding:.8rem 1rem}
-    .mobile-dropdown-toggle{display:flex;align-items:center;justify-content:space-between;cursor:pointer;font-size:1.1rem;text-transform:uppercase;letter-spacing:.15em;font-weight:600;font-family:Montserrat,sans-serif;color:var(--white);padding:1rem;border-left:3px solid transparent;transition:all .3s}
-    .mobile-dropdown-toggle::after{content:'▼';font-size:.7rem;transition:transform .3s}
-    .mobile-dropdown-toggle.active::after{transform:rotate(180deg)}
-    .mobile-dropdown-toggle:hover{color:var(--gold);border-left-color:var(--orange)}
-    .mobile-menu-contacts{border-top:1px solid rgba(74,155,142,.3);padding-top:1.5rem}
-    .mobile-menu-contacts h3{font-size:.9rem;color:var(--gold);margin-bottom:1rem;letter-spacing:.2em;text-transform:uppercase}
-    .mobile-menu-contacts p{font-size:.85rem;margin-bottom:.5rem;color:var(--white-dim)}
-    .mobile-menu-contacts a{color:var(--white);text-decoration:none;transition:color .3s}
-
-    /* PROGRESS BAR CENTRALE OTTIMIZZATA */
-    .progress-bar-container{position:fixed;top:0;left:50%;transform:translateX(-50%);width:4px;height:100vh;z-index:999;pointer-events:none;opacity:0;transition:opacity .8s ease}
-    .progress-bar-container.visible{opacity:1}
-    .progress-bar{position:absolute;top:0;left:0;width:100%;height:0;background:linear-gradient(180deg,rgba(255,107,53,0) 0%,rgba(255,107,53,.9) 15%,rgba(212,175,55,.95) 50%,rgba(74,155,142,.9) 85%,rgba(74,155,142,0) 100%);box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5);transition:height .1s linear;filter:blur(.8px);will-change:height;animation:progressGlow 3s ease-in-out infinite}
-    @keyframes progressGlow{0%,100%{box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5)}50%{box-shadow:0 0 40px rgba(255,215,0,1),0 0 70px rgba(255,140,0,.9),0 0 100px rgba(255,107,53,.7)}}
-    .progress-bar::before{content:'';position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);width:16px;height:16px;background:radial-gradient(circle,var(--gold),transparent);border-radius:50%;box-shadow:0 0 20px var(--gold),0 0 30px var(--orange);animation:dotPulse 2s ease-in-out infinite}
-    @keyframes dotPulse{0%,100%{transform:translateX(-50%) scale(1);opacity:1}50%{transform:translateX(-50%) scale(1.5);opacity:.8}}
-    .progress-bar.section-pulse{animation:sectionPulse .8s ease-out,progressGlow 3s ease-in-out infinite}
-    @keyframes sectionPulse{0%{box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5);width:4px;filter:blur(.8px)}20%{box-shadow:0 0 50px rgba(255,215,0,1),0 0 90px rgba(255,140,0,1),0 0 130px rgba(255,107,53,.9);width:8px;filter:blur(1.5px)}60%{box-shadow:0 0 50px rgba(255,215,0,1),0 0 90px rgba(255,140,0,1),0 0 130px rgba(255,107,53,.9);width:8px;filter:blur(1.5px)}100%{box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5);width:4px;filter:blur(.8px)}}
-
-    .scroll-indicator{position:absolute;bottom:2rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.5rem;opacity:0;transition:opacity .5s;z-index:30;cursor:pointer}
-    section.visible .scroll-indicator{opacity:.8}
-    .scroll-indicator:hover{opacity:1}
-    .scroll-text{font-size:.7rem;letter-spacing:.3em;color:var(--gold);text-transform:uppercase;font-weight:600;text-shadow:0 0 10px rgba(212,175,55,.6);animation:textFloat 3s ease-in-out infinite}
-    @keyframes textFloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-5px)}}
-    .scroll-icon{width:24px;height:40px;border:2px solid var(--gold);border-radius:15px;position:relative;transition:all .3s;box-shadow:0 0 10px rgba(212,175,55,.4)}
-    .scroll-icon::before{content:'';position:absolute;top:6px;left:50%;transform:translateX(-50%);width:3px;height:6px;background:var(--gold);border-radius:3px;animation:scrollDot 2s ease-in-out infinite;box-shadow:0 0 5px var(--gold)}
-    @keyframes scrollDot{0%{top:6px;opacity:1}100%{top:26px;opacity:0}}
-
-    section{min-height:100vh;display:flex;align-items:center;justify-content:flex-start;position:relative;padding:6rem var(--left) 6rem 5%;opacity:0;transform:translateY(60px);transition:opacity 1s,transform 1s;z-index:20}
-    section.visible{opacity:1;transform:translateY(0)}
-    .section-content{max-width:900px;width:100%;text-align:left;z-index:20;position:relative;padding:3rem;border-radius:15px}
-    .section-bg{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:70%;max-width:900px;height:80%;z-index:-1;background-size:cover;background-position:center;opacity:0;filter:brightness(.55)contrast(1.3)saturate(1.4)sepia(.3);transition:opacity 2s,filter 2s;-webkit-mask-image:linear-gradient(to bottom,rgba(0,0,0,.8)0%,rgba(0,0,0,.5)60%,transparent 100%);mask-image:linear-gradient(to bottom,rgba(0,0,0,.8)0%,rgba(0,0,0,.5)60%,transparent 100%);mix-blend-mode:luminosity;border-radius:20px}
-    #hero .section-bg{background-image:url('https://images.unsplash.com/photo-1518709268801-4f5d3f4c5c3d?w=1200&q=80&auto=format&fit=crop')}
-    #about .section-bg{background-image:url('https://images.unsplash.com/photo-1559136555-9303baea8ebd?w=1200&q=80&auto=format&fit=crop')}
-    #mission .section-bg{background-image:url('https://images.unsplash.com/photo-1552664730-d307ca884978?w=1200&q=80&auto=format&fit=crop')}
-    #vision .section-bg{background-image:url('https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=1200&q=80&auto=format&fit=crop')}
-    #values .section-bg{background-image:url('https://images.unsplash.com/photo-1553484771-371a605b060b?w=1200&q=80&auto=format&fit=crop')}
-    #services .section-bg{background-image:url('https://images.unsplash.com/photo-1559028012-481c04fa702d?w=1200&q=80&auto=format&fit=crop')}
-    #team .section-bg{background-image:url('https://images.unsplash.com/photo-1556761175-5973dc0f32e7?w=1200&q=80&auto=format&fit=crop')}
-    #testimonials .section-bg{background-image:url('https://images.unsplash.com/photo-1551836026-d5c88ac5d69a?w=1200&q=80&auto=format&fit=crop')}
-    #blog .section-bg{background-image:url('https://images.unsplash.com/photo-1586953208448-b95a79798f07?w=1200&q=80&auto=format&fit=crop')}
-    #contact .section-bg{background-image:url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=1200&q=80&auto=format&fit=crop')}
-    section.visible .section-bg{opacity:1;filter:brightness(.55)contrast(1.4)saturate(1.5)sepia(.3)}
-    .section-subtitle{font-size:.9rem;letter-spacing:.4em;color:var(--gold);margin-bottom:1.5rem;font-weight:600;text-transform:uppercase;opacity:0;transition:opacity 1s .2s;text-shadow:0 0 15px rgba(255,107,53,.5);animation:textFloat 4s ease-in-out infinite}
-    section.visible .section-subtitle{opacity:1}
-    .section-title{font-size:clamp(2.5rem,6vw,4.5rem);font-weight:900;margin-bottom:2rem;line-height:1;background:linear-gradient(135deg,var(--white),var(--gold-light),var(--orange),var(--teal));background-size:200% 100%;-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:-.02em;opacity:0;transition:opacity 1s .4s;position:relative;filter:drop-shadow(0 2px 15px rgba(255,107,53,.4));animation:titleFloat 5s ease-in-out infinite}
-    @keyframes titleFloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-8px)}}
-    section.visible .section-title{opacity:1}
-    .section-text{font-size:1.15rem;line-height:1.9;color:var(--white);font-weight:400;margin-bottom:2.5rem;opacity:0;transition:opacity 1s .6s;text-shadow:0 1px 3px rgba(0,0,0,.6);animation:textFloat 6s ease-in-out infinite}
-    section.visible .section-text{opacity:1}
-    .hero-title{font-size:clamp(3rem,8vw,6.5rem);font-weight:900;line-height:.95;margin-bottom:2rem;background:linear-gradient(135deg,#ffd700,#ff6b35,#4a9b8e,var(--white),var(--gold));background-size:300% 100%;-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:-.03em;filter:drop-shadow(0 3px 20px rgba(255,107,53,.6));animation:heroFloat 4s ease-in-out infinite}
-    @keyframes heroFloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-12px)}}
-    .cta-button{display:inline-block;padding:1.2rem 3rem;background:rgba(10,14,20,.9);border:2px solid var(--gold);color:var(--gold);text-decoration:none;text-transform:uppercase;letter-spacing:.25em;font-size:.85rem;font-weight:700;transition:all .5s;position:relative;overflow:hidden;border-radius:4px;box-shadow:0 0 20px rgba(212,175,55,.3),inset 0 0 10px rgba(255,107,53,.1)}
-    .cta-button::before{content:'';position:absolute;top:50%;left:50%;width:0;height:0;background:linear-gradient(135deg,var(--orange),var(--gold),var(--teal));transition:all .5s;transform:translate(-50%,-50%);border-radius:50%;z-index:-1}
-    .cta-button:hover{color:#000;transform:translateY(-3px);box-shadow:0 10px 30px rgba(255,107,53,.5)}
-    .cta-button:hover::before{width:500px;height:500px}
-    .services-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:2rem;margin-top:3rem}
-
-    /* OVERLAY PER EFFETTO OSCURAMENTO */
-    .card-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);backdrop-filter:blur(3px);opacity:0;visibility:hidden;transition:opacity .4s,visibility .4s;z-index:998;pointer-events:none}
-    .card-overlay.active{opacity:1;visibility:visible;pointer-events:auto}
-
-    /* VAULT CARDS OTTIMIZZATE */
-    .vault-card,.service-card,.team-card,.testimonial-card,.blog-card{position:relative;will-change:transform;transition:transform .3s,opacity .3s,box-shadow .3s}
-    .cards-dimmed .vault-card:not(.flipped),.cards-dimmed .service-card:not(.flipped),.cards-dimmed .team-card:not(.flipped),.cards-dimmed .testimonial-card:not(.flipped),.cards-dimmed .blog-card:not(.flipped){opacity:.4;transform:scale(.98)}
-    .vault-card.flipped,.service-card.flipped,.team-card.flipped,.testimonial-card.flipped,.blog-card.flipped{z-index:999;transform:scale(1.08)!important;opacity:1!important;box-shadow:0 25px 80px rgba(0,0,0,.9),0 0 60px rgba(255,107,53,.6)!important}
-
-    .service-card{background:linear-gradient(135deg,rgba(13,27,42,.95),rgba(10,14,20,.98));border:2px solid rgba(74,155,142,.25);border-radius:12px;padding:2.5rem 1.5rem;text-align:center;cursor:pointer;overflow:hidden;box-shadow:0 5px 20px rgba(0,0,0,.5),inset 0 1px 0 rgba(74,155,142,.1),0 0 30px rgba(212,175,55,.15);perspective:1000px;min-height:420px}
-    .service-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d}
-    .service-card.flipped .service-card-inner{transform:rotateY(180deg)}
-    .service-front,.service-back{position:absolute;width:100%;height:100%;backface-visibility:hidden;display:flex;flex-direction:column;align-items:center;justify-content:center}
-    .service-back{transform:rotateY(180deg);padding:1.5rem}
-    .service-card::before{content:'';position:absolute;inset:0;background-size:cover;background-position:center;opacity:0;transition:opacity .4s;z-index:0;border-radius:12px}
-    .service-card:nth-child(1)::before{background-image:url('https://images.unsplash.com/photo-1561070791-2526d30994b5?w=600&q=80')}
-    .service-card:nth-child(2)::before{background-image:url('https://images.unsplash.com/photo-1455390582262-044cdead277a?w=600&q=80')}
-    .service-card:nth-child(3)::before{background-image:url('https://images.unsplash.com/photo-1561070791-36c11767b26a?w=600&q=80')}
-    .service-card:nth-child(4)::before{background-image:url('https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=600&q=80')}
-    .service-card:nth-child(5)::before{background-image:url('https://images.unsplash.com/photo-1432888498266-38ffec3eaf0a?w=600&q=80')}
-    .service-card:nth-child(6)::before{background-image:url('https://images.unsplash.com/photo-1611162617474-5b21e879e113?w=600&q=80')}
-    .service-card::after{content:'';position:absolute;inset:0;background:rgba(10,14,20,.85);z-index:1;transition:background .4s;border-radius:12px}
-    .service-card.flipped::before{opacity:1}
-    .service-card.flipped::after{background:rgba(10,14,20,.5)}
-    .service-icon{font-size:3.5rem;margin-bottom:1.5rem;display:block;position:relative;z-index:2;filter:drop-shadow(0 0 10px rgba(212,175,55,.5))}
-    .service-card h3{font-size:1.3rem;font-weight:800;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:1rem;text-transform:uppercase;letter-spacing:.1em;position:relative;z-index:2}
-    .service-card p{font-size:.95rem;line-height:1.6;color:var(--white);position:relative;z-index:2;text-shadow:0 1px 2px rgba(0,0,0,.5)}
-    .service-back p{font-size:.9rem;line-height:1.7;margin-bottom:1.5rem}
-    .service-cta{display:inline-block;padding:.8rem 1.8rem;background:rgba(212,175,55,.1);border:2px solid var(--gold);color:var(--gold);text-decoration:none;font-size:.75rem;text-transform:uppercase;letter-spacing:.2em;font-weight:700;border-radius:4px;position:relative;z-index:2;transition:all .3s;overflow:hidden}
-    .service-cta::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--orange),var(--gold));opacity:0;transition:opacity .3s;z-index:-1}
-    .service-cta:hover{color:#000}
-    .service-cta:hover::before{opacity:1}
-
-    .carousel-nav{display:flex;justify-content:flex-start;gap:1rem;margin-top:2rem}
-    .carousel-arrow{background:linear-gradient(135deg,rgba(13,27,42,.95),rgba(10,14,20,.9));border:2px solid var(--gold);color:var(--gold);width:50px;height:50px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all .4s;font-size:1.5rem;font-weight:700;user-select:none;position:relative;overflow:hidden;box-shadow:0 4px 15px rgba(0,0,0,.4),0 0 15px rgba(212,175,55,.2)}
-    .carousel-arrow::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--orange),var(--gold),var(--teal));opacity:0;transition:opacity .3s}
-    .carousel-arrow:hover{background:var(--gold);color:#000;transform:scale(1.2);box-shadow:0 6px 20px rgba(255,107,53,.5)}
-    .carousel-arrow:hover::before{opacity:1}
-    .slider-container{max-width:100%;overflow:hidden;position:relative}
-    .slider-wrapper{display:flex;gap:2rem;padding:2rem 0;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;scrollbar-width:none;-webkit-overflow-scrolling:touch}
-    .slider-wrapper::-webkit-scrollbar{display:none}
-    .vault-card,.testimonial-card,.blog-card,.team-card{flex-shrink:0;scroll-snap-align:center}
-    .vault-card{min-width:320px;max-width:320px;height:420px;perspective:1000px;cursor:pointer}
-    .vault-door{width:100%;height:100%;position:relative;transform-style:preserve-3d;transition:transform .8s}
-    .vault-card.flipped .vault-door{transform:rotateY(180deg)}
-    .vault-front,.vault-back{position:absolute;width:100%;height:100%;backface-visibility:hidden;border-radius:10px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem 1.5rem;box-shadow:0 10px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15)}
-    .vault-front{background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.4)}
-    .vault-back{background:linear-gradient(135deg,rgba(10,14,20,1),rgba(13,27,42,1));border:2px solid var(--orange);transform:rotateY(180deg)}
-    .vault-lock{width:80px;height:80px;border:4px solid var(--gold);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:2.5rem;margin-bottom:1.5rem;background:radial-gradient(circle,rgba(255,107,53,.3),rgba(0,0,0,.9));box-shadow:0 0 30px rgba(212,175,55,.6)}
-    .vault-front h3,.vault-back h3{font-size:1.3rem;font-weight:800;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:.2em;text-align:center}
-    .vault-hint{margin-top:1rem;font-size:.75rem;color:var(--white-dim);letter-spacing:.2em}
-    .vault-icon{font-size:3rem;margin-bottom:1.5rem;filter:drop-shadow(0 0 15px rgba(255,107,53,.7))}
-    .vault-back p{font-size:.95rem;line-height:1.7;color:var(--white);text-align:center;margin-bottom:1rem}
-    .vault-cta{display:inline-block;padding:.7rem 1.5rem;background:rgba(212,175,55,.1);border:1px solid var(--gold);color:var(--gold);text-decoration:none;font-size:.75rem;text-transform:uppercase;letter-spacing:.2em;font-weight:700;border-radius:4px;transition:all .3s;margin-top:1rem}
-    .vault-cta:hover{background:var(--gold);color:#000}
-
-    .team-card{min-width:340px;max-width:340px;background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.3);border-radius:12px;overflow:hidden;box-shadow:0 15px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15);perspective:1000px;min-height:500px;cursor:pointer}
-    .team-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d}
-    .team-card.flipped .team-card-inner{transform:rotateY(180deg)}
-    .team-front,.team-back{position:absolute;width:100%;height:100%;backface-visibility:hidden}
-    .team-back{transform:rotateY(180deg);background:linear-gradient(135deg,rgba(10,14,20,1),rgba(13,27,42,1));border:2px solid var(--orange);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem;text-align:center}
-    .team-photo{width:100%;height:280px;background-size:cover;background-position:center;position:relative;filter:brightness(1.05)contrast(1.1)}
-    .team-card:nth-child(1) .team-photo{background-image:url('https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=500&fit=crop&crop=faces')}
-    .team-card:nth-child(2) .team-photo{background-image:url('https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=500&fit=crop&crop=faces')}
-    .team-card:nth-child(3) .team-photo{background-image:url('https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=400&h=500&fit=crop&crop=faces')}
-    .team-card:nth-child(4) .team-photo{background-image:url('https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=400&h=500&fit=crop&crop=faces')}
-    .team-card:nth-child(5) .team-photo{background-image:url('https://images.unsplash.com/photo-1580489944761-15a19d654956?w=400&h=500&fit=crop&crop=faces')}
-    .team-info{padding:1.5rem}
-    .team-name{font-size:1.2rem;font-weight:800;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:.5rem}
-    .team-role{color:var(--gold);font-size:.85rem;font-weight:600;letter-spacing:.15em;text-transform:uppercase;margin-bottom:.8rem}
-    .team-bio{font-size:.85rem;line-height:1.6;color:var(--white-dim);margin-bottom:1rem}
-    .team-social{display:flex;gap:.8rem;justify-content:center}
-    .team-social a{width:32px;height:32px;display:flex;align-items:center;justify-content:center;border-radius:50%;background:rgba(212,175,55,.1);border:1px solid var(--gold);transition:all .3s}
-    .team-social a:hover{background:var(--gold);transform:scale(1.1)}
-    .team-social svg{width:16px;height:16px;fill:var(--gold);transition:fill .3s}
-    .team-social a:hover svg{fill:#000}
-    .team-join{text-align:left;margin-top:2rem}
-    .team-join a{display:inline-block;padding:1rem 2rem;background:rgba(10,14,20,.9);border:2px solid var(--gold);color:var(--gold);text-decoration:none;text-transform:uppercase;letter-spacing:.2em;font-size:.85rem;font-weight:700;border-radius:6px;transition:all .4s;box-shadow:0 0 15px rgba(212,175,55,.3)}
-    .team-join a:hover{background:linear-gradient(135deg,var(--orange),var(--gold));color:#000;transform:translateY(-2px);box-shadow:0 10px 25px rgba(255,107,53,.5)}
-
-    .testimonial-card{min-width:300px;max-width:300px;padding:2.5rem 2rem;background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.3);border-radius:15px;display:flex;flex-direction:column;align-items:center;box-shadow:0 15px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15);min-height:420px;overflow:hidden;perspective:1000px;cursor:pointer}
-    .testimonial-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d;display:flex;flex-direction:column;align-items:center;justify-content:center}
-    .testimonial-card.flipped .testimonial-card-inner{transform:rotateY(180deg)}
-    .testimonial-front,.testimonial-back{position:absolute;width:100%;height:100%;backface-visibility:hidden;display:flex;flex-direction:column;align-items:center;justify-content:center}
-    .testimonial-back{transform:rotateY(180deg);padding:1.5rem}
-    .testimonial-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--orange),var(--gold),var(--teal),transparent);opacity:.7;z-index:1}
-    .testimonial-card::after{content:'"';position:absolute;top:1rem;right:1.5rem;font-size:6rem;color:rgba(255,107,53,.15);font-family:Georgia,serif;line-height:1;z-index:0}
-    .testimonial-image{width:70px;height:70px;border-radius:50%;border:3px solid var(--gold);margin-bottom:1.5rem;background-size:cover;background-position:center;box-shadow:0 0 20px rgba(212,175,55,.5);position:relative;z-index:2}
-    .testimonial-card:nth-child(1) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=12')}
-    .testimonial-card:nth-child(2) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=5')}
-    .testimonial-card:nth-child(3) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=33')}
-    .testimonial-card:nth-child(4) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=9')}
-    .testimonial-card:nth-child(5) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=13')}
-    .testimonial-card:nth-child(6) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=14')}
-    .testimonial-card:nth-child(7) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=20')}
-    .testimonial-card:nth-child(8) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=68')}
-    .testimonial-card:nth-child(9) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=27')}
-    .testimonial-card:nth-child(10) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=32')}
-    .testimonial-text{font-size:1rem;line-height:1.7;color:var(--white);font-style:italic;margin-bottom:1.5rem;text-align:center;position:relative;z-index:2}
-    .testimonial-author{font-size:1rem;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:700;margin-bottom:.3rem;letter-spacing:.05em;position:relative;z-index:2}
-    .testimonial-company{font-size:.85rem;color:var(--white-dim);letter-spacing:.1em;position:relative;z-index:2}
-
-    .blog-card{min-width:340px;max-width:340px;background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.3);border-radius:12px;overflow:hidden;box-shadow:0 15px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15);min-height:480px;perspective:1000px;cursor:pointer}
-    .blog-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d}
-    .blog-card.flipped .blog-card-inner{transform:rotateY(180deg)}
-    .blog-front,.blog-back{position:absolute;width:100%;height:100%;backface-visibility:hidden}
-    .blog-back{transform:rotateY(180deg);background:linear-gradient(135deg,rgba(10,14,20,1),rgba(13,27,42,1));border:2px solid var(--orange);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem;text-align:center}
-    .blog-image{width:100%;height:200px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;background-size:cover;background-position:center}
-    .blog-card:nth-child(1) .blog-image{background-image:url('https://images.unsplash.com/photo-1499750310107-5fef28a66643?w=600&q=80')}
-    .blog-card:nth-child(2) .blog-image{background-image:url('https://images.unsplash.com/photo-1558655146-9f40138edfeb?w=600&q=80')}
-    .blog-card:nth-child(3) .blog-image{background-image:url('https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=600&q=80')}
-    .blog-card:nth-child(4) .blog-image{background-image:url('https://images.unsplash.com/photo-1556155092-490a1ba16284?w=600&q=80')}
-    .blog-card:nth-child(5) .blog-image{background-image:url('https://images.unsplash.com/photo-1552664730-d307ca884978?w=600&q=80')}
-    .blog-card:nth-child(6) .blog-image{background-image:url('https://images.unsplash.com/photo-1486312338219-ce68d2c6f44d?w=600&q=80')}
-    .blog-card:nth-child(7) .blog-image{background-image:url('https://images.unsplash.com/photo-1533750516457-a7f992034fec?w=600&q=80')}
-    .blog-card:nth-child(8) .blog-image{background-image:url('https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=600&q=80')}
-    .blog-card:nth-child(9) .blog-image{background-image:url('https://images.unsplash.com/photo-1542744173-8e7e53415bb0?w=600&q=80')}
-    .blog-card:nth-child(10) .blog-image{background-image:url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=600&q=80')}
-    .blog-image::before{content:'';position:absolute;inset:0;background:linear-gradient(to bottom,rgba(10,14,20,.2),rgba(10,14,20,.6))}
-    .blog-content{padding:2rem 1.5rem}
-    .blog-date{font-size:.75rem;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:.25em;margin-bottom:.8rem;font-weight:700}
-    .blog-title{font-size:1.3rem;color:var(--white);margin-bottom:.6rem;font-weight:800;line-height:1.3}
-    .blog-subtitle{font-size:.9rem;color:var(--gold);margin-bottom:.8rem;font-weight:600}
-    .blog-excerpt{font-size:.9rem;color:var(--white-dim);line-height:1.6}
-
-    .contact-form{max-width:700px;width:100%;margin:3rem 0 0}
-    .form-row{display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-bottom:1.5rem}
-    .form-group{width:100%}
-    .form-group.full-width{grid-column:1/-1}
-    .form-input,.form-select,.form-textarea{width:100%;padding:1.2rem;background:rgba(13,27,42,.9);border:2px solid rgba(74,155,142,.3);color:var(--white);font-family:inherit;font-size:.95rem;transition:all .4s;border-radius:6px;box-shadow:inset 0 2px 5px rgba(0,0,0,.4)}
-    .form-input:focus,.form-select:focus,.form-textarea:focus{outline:0;border-color:var(--orange);background:rgba(13,27,42,.95);box-shadow:0 0 20px rgba(255,107,53,.3)}
-    .form-textarea{resize:vertical;min-height:140px}
-    .form-submit{width:100%;padding:1.2rem;background:rgba(10,14,20,.9);border:2px solid var(--gold);color:var(--gold);text-transform:uppercase;letter-spacing:.25em;font-size:.9rem;font-weight:700;cursor:pointer;transition:all .5s;position:relative;overflow:hidden;border-radius:6px;box-shadow:0 0 20px rgba(212,175,55,.3)}
-    .form-submit::before{content:'';position:absolute;top:50%;left:50%;width:0;height:0;background:linear-gradient(135deg,var(--orange),var(--gold),var(--teal));transition:all .5s;transform:translate(-50%,-50%);border-radius:50%;z-index:-1}
-    .form-submit:hover{color:#000;transform:translateY(-3px);box-shadow:0 10px 30px rgba(255,107,53,.5)}
-    .form-submit:hover::before{width:700px;height:700px}
-
-    footer{padding:4rem 5%;border-top:1px solid rgba(74,155,142,.3);margin-top:8rem;position:relative;z-index:20;background:rgba(10,14,20,.5)}
-    .sub-footer{display:grid;grid-template-columns:repeat(4,1fr);gap:3rem;margin-bottom:3rem}
-    .footer-section h3{font-size:1rem;color:var(--gold);margin-bottom:1.5rem;text-transform:uppercase;letter-spacing:.2em;font-weight:800}
-    .footer-bio{color:var(--white-dim);line-height:1.7;font-size:.9rem}
-    .footer-menu{list-style:none}
-    .footer-menu li{margin-bottom:.8rem}
-    .footer-menu a{color:var(--white-dim);text-decoration:none;font-size:.9rem;transition:color .3s}
-    .footer-menu a:hover{color:var(--gold)}
-    .footer-contact{color:var(--white-dim);font-size:.9rem;line-height:1.8}
-    .footer-contact a{color:var(--white);text-decoration:none;transition:color .3s}
-    .footer-contact a:hover{color:var(--gold)}
-    .newsletter-form{display:flex;gap:.5rem}
-    .newsletter-input{flex:1;padding:.8rem;background:rgba(13,27,42,.9);border:2px solid rgba(74,155,142,.3);color:var(--white);font-family:inherit;font-size:.85rem;border-radius:4px}
-    .newsletter-btn{padding:.8rem 1.5rem;background:linear-gradient(135deg,var(--orange),var(--gold));color:#000;border:none;font-weight:700;text-transform:uppercase;letter-spacing:.1em;font-size:.75rem;border-radius:4px;cursor:pointer;transition:all .3s;position:relative;overflow:hidden}
-    .newsletter-btn::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--orange),var(--gold));opacity:.6;filter:blur(15px);z-index:-1;animation:ctaPulse 2s ease-in-out infinite}
-    .newsletter-btn:hover{transform:translateY(-2px);box-shadow:0 5px 15px rgba(255,107,53,.5)}
-    .footer-bottom{display:flex;justify-content:space-between;align-items:center;padding-top:2rem;border-top:1px solid rgba(74,155,142,.2);flex-wrap:wrap;gap:1rem}
-    .footer-text{font-size:.9rem;color:var(--white-dim);letter-spacing:.1em}
-    .footer-links{display:flex;gap:2rem}
-    .footer-links a{color:var(--white-dim);text-decoration:none;font-size:.85rem;transition:color .3s}
-    .footer-links a:hover{color:var(--gold)}
-
-    #tower3DContainer{position:fixed;top:0;right:0;width:clamp(320px,38vw,600px);height:100vh;z-index:0;pointer-events:none;background:transparent;border:none;box-shadow:none}
-    #tower3DContainer canvas{display:block;width:100%!important;height:100%!important}
-    #particleCanvas{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:1;opacity:.7}
-    .light-glow{position:fixed;width:600px;height:600px;border-radius:50%;background:radial-gradient(circle,rgba(212,175,55,.4),rgba(255,107,53,.2),transparent);filter:blur(100px);pointer-events:none;z-index:2;opacity:0;transition:opacity 1s}
-    .light-glow.active{opacity:1}
-
-    @media(max-width:1024px){
-        .nav-menu{display:none}
-        .vault-card,.testimonial-card,.blog-card,.team-card{min-width:280px;max-width:280px}
-        .vault-card{height:380px}
-        #tower3DContainer{opacity:.4!important;width:clamp(280px,50vw,400px)}
-        .sub-footer{grid-template-columns:1fr 1fr}
-        .cursor,.cursor-follower{display:none}
-    }
-    @media(max-width:768px){
-        nav{padding:1rem 5%}
-        section{padding:5rem 5%}
-        .section-content{padding:2.5rem 1.5rem}
-        .form-row{grid-template-columns:1fr}
-        .vault-card,.testimonial-card,.blog-card,.team-card{min-width:260px;max-width:260px}
-        .vault-card{height:360px}
-        .services-grid{grid-template-columns:1fr}
-        .sub-footer{grid-template-columns:1fr}
-        .footer-bottom{flex-direction:column;text-align:center}
-        .hero-title{font-size:clamp(2.5rem,7vw,5rem)}
-    }
-    @media(max-width:480px){
-        .section-content{padding:2rem 1rem}
-        .vault-card,.testimonial-card,.blog-card,.team-card{min-width:240px;max-width:240px}
-        .mobile-menu{max-width:100%}
-    }
-</style>
-</head>
-<body>
-
-<div class="loader" id="loader">
-    <svg class="loader-tower" viewBox="0 0 180 260" xmlns="http://www.w3.org/2000/svg">
+<!doctype html>
+<html lang="it">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"
+    />
+    <meta
+      name="description"
+      content="Digital Tower - Agenzia digitale di marketing e comunicazione a Napoli. Trasformiamo la tua visione in successo digitale attraverso web design innovativo, branding distintivo, contenuti coinvolgenti e strategie di marketing data-driven che generano risultati concreti e misurabili."
+    />
+    <meta
+      name="keywords"
+      content="web design Napoli, agenzia digitale Napoli, branding Napoli, marketing digitale, sviluppo web, SEO Italia, social media marketing, content marketing, web agency Napoli, digital marketing Italia"
+    />
+    <meta name="theme-color" content="#d4af37" />
+    <meta
+      property="og:title"
+      content="Digital Tower - Trasforma la Tua Visione in Successo Digitale"
+    />
+    <meta
+      property="og:description"
+      content="Agenzia digitale specializzata in web design, branding e strategie digitali che generano risultati concreti"
+    />
+    <meta property="og:type" content="website" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;800;900&display=swap"
+      rel="stylesheet"
+    />
+    <script
+      src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"
+      defer
+    ></script>
+    <title>Digital Tower - Scaliamo Insieme la Torre del Successo</title>
+    <link rel="stylesheet" href="assets/css/base/variables.css" />
+    <link rel="stylesheet" href="assets/css/base/base.css" />
+    <link rel="stylesheet" href="assets/css/components/loader.css" />
+    <link rel="stylesheet" href="assets/css/components/background.css" />
+    <link rel="stylesheet" href="assets/css/components/cursor.css" />
+    <link rel="stylesheet" href="assets/css/layout/navigation.css" />
+    <link
+      rel="stylesheet"
+      href="assets/css/components/scroll-indicators.css"
+    />
+    <link rel="stylesheet" href="assets/css/layout/sections.css" />
+    <link rel="stylesheet" href="assets/css/components/cards.css" />
+    <link rel="stylesheet" href="assets/css/components/forms.css" />
+    <link rel="stylesheet" href="assets/css/layout/footer.css" />
+    <link rel="stylesheet" href="assets/css/components/tower-effects.css" />
+    <link rel="stylesheet" href="assets/css/utilities/responsive.css" />
+  </head>
+  <body>
+    <div class="loader" id="loader">
+      <svg
+        class="loader-tower"
+        viewBox="0 0 180 260"
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <defs>
-            <linearGradient id="g1" x1="0%" y1="0%" x2="0%" y2="100%">
-                <stop offset="0%" style="stop-color:#ffd700;stop-opacity:1"/>
-                <stop offset="100%" style="stop-color:#ff6b35;stop-opacity:1"/>
-            </linearGradient>
+          <linearGradient id="g1" x1="0%" y1="0%" x2="0%" y2="100%">
+            <stop offset="0%" style="stop-color: #ffd700; stop-opacity: 1" />
+            <stop offset="100%" style="stop-color: #ff6b35; stop-opacity: 1" />
+          </linearGradient>
         </defs>
-        <g fill="none" stroke="url(#g1)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M90 10 L90 26" style="--len:16;animation-delay:0s"/>
-            <path d="M78 26 Q90 18 102 26 L102 40 Q90 34 78 40 Z" style="--len:50;animation-delay:.1s"/>
-            <path d="M68 40 L112 40 L112 210 L68 210 Z" style="--len:504;animation-delay:.2s"/>
-            <path d="M68 60 Q90 54 112 60" style="--len:50;animation-delay:.3s"/>
-            <path d="M68 82 Q90 76 112 82" style="--len:50;animation-delay:.4s"/>
-            <path d="M68 104 Q90 98 112 104" style="--len:50;animation-delay:.5s"/>
-            <path d="M68 126 Q90 120 112 126" style="--len:50;animation-delay:.6s"/>
-            <path d="M68 148 Q90 142 112 148" style="--len:50;animation-delay:.7s"/>
-            <path d="M68 170 Q90 164 112 170" style="--len:50;animation-delay:.8s"/>
-            <path d="M58 210 L122 210 L122 230 L58 230 Z" style="--len:192;animation-delay:.9s"/>
-            <path d="M10 240 L10 222 26 222 26 212 42 212 42 240" style="--len:90;animation-delay:1s" opacity="0.6"/>
-            <path d="M138 240 L138 218 150 218 150 210 166 210 166 240" style="--len:90;animation-delay:1.1s" opacity="0.6"/>
-            <path d="M6 240 L174 240" style="--len:168;animation-delay:1.2s" opacity="0.6"/>
+        <g
+          fill="none"
+          stroke="url(#g1)"
+          stroke-width="3"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+        >
+          <path d="M90 10 L90 26" style="--len: 16; animation-delay: 0s" />
+          <path
+            d="M78 26 Q90 18 102 26 L102 40 Q90 34 78 40 Z"
+            style="--len: 50; animation-delay: 0.1s"
+          />
+          <path
+            d="M68 40 L112 40 L112 210 L68 210 Z"
+            style="--len: 504; animation-delay: 0.2s"
+          />
+          <path
+            d="M68 60 Q90 54 112 60"
+            style="--len: 50; animation-delay: 0.3s"
+          />
+          <path
+            d="M68 82 Q90 76 112 82"
+            style="--len: 50; animation-delay: 0.4s"
+          />
+          <path
+            d="M68 104 Q90 98 112 104"
+            style="--len: 50; animation-delay: 0.5s"
+          />
+          <path
+            d="M68 126 Q90 120 112 126"
+            style="--len: 50; animation-delay: 0.6s"
+          />
+          <path
+            d="M68 148 Q90 142 112 148"
+            style="--len: 50; animation-delay: 0.7s"
+          />
+          <path
+            d="M68 170 Q90 164 112 170"
+            style="--len: 50; animation-delay: 0.8s"
+          />
+          <path
+            d="M58 210 L122 210 L122 230 L58 230 Z"
+            style="--len: 192; animation-delay: 0.9s"
+          />
+          <path
+            d="M10 240 L10 222 26 222 26 212 42 212 42 240"
+            style="--len: 90; animation-delay: 1s"
+            opacity="0.6"
+          />
+          <path
+            d="M138 240 L138 218 150 218 150 210 166 210 166 240"
+            style="--len: 90; animation-delay: 1.1s"
+            opacity="0.6"
+          />
+          <path
+            d="M6 240 L174 240"
+            style="--len: 168; animation-delay: 1.2s"
+            opacity="0.6"
+          />
         </g>
-    </svg>
-    <div class="loader-text" id="loaderText"></div>
-    <div class="loader-bar-wrap">
+      </svg>
+      <div class="loader-text" id="loaderText"></div>
+      <div class="loader-progress" id="loaderProgress">0%</div>
+      <div class="loader-bar-wrap">
         <div class="loader-bar" id="loaderBar"></div>
+      </div>
     </div>
-</div>
 
-<div class="vignette"></div>
-<div class="progress-bar-container" id="progressBarContainer">
-    <div class="progress-bar" id="progressBar"></div>
-</div>
-<div class="cursor"></div>
-<div class="cursor-follower"></div>
-<div class="card-overlay" id="cardOverlay"></div>
+    <div class="vignette"></div>
+    <div class="cursor"></div>
+    <div class="cursor-follower"></div>
+    <div class="card-overlay" id="cardOverlay"></div>
 
-<div class="carbon-fiber"></div>
-<canvas id="particleCanvas"></canvas>
-<div class="light-glow" id="lightGlow1" style="top:20%;left:10%"></div>
-<div class="light-glow" id="lightGlow2" style="top:60%;right:10%"></div>
+    <div class="carbon-fiber"></div>
+    <canvas id="particleCanvas"> </canvas>
+    <div class="light-glow" id="lightGlow1" style="top: 20%; left: 10%"></div>
+    <div class="light-glow" id="lightGlow2" style="top: 60%; right: 10%"></div>
 
-<nav id="mainNav">
-    <div class="nav-logo" onclick="scrollToSection('hero')">DIGITAL TOWER</div>
-    <ul class="nav-menu">
+    <nav id="mainNav">
+      <div class="nav-logo" onclick="scrollToSection('hero')">
+        DIGITAL TOWER
+      </div>
+      <ul class="nav-menu">
         <li class="nav-dropdown">
-            <a href="javascript:void(0)">Chi Siamo</a>
-            <ul class="nav-dropdown-menu">
-                <li><a href="javascript:void(0)" onclick="scrollToSection('mission')">Missione</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('vision')">Visione</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('values')">Valori</a></li>
-            </ul>
+          <a href="javascript:void(0)">Chi Siamo</a>
+          <ul class="nav-dropdown-menu">
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('mission')"
+                >Missione</a
+              >
+            </li>
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('vision')"
+                >Visione</a
+              >
+            </li>
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('values')"
+                >Valori</a
+              >
+            </li>
+          </ul>
         </li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('services')">Servizi</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('team')">Team</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('testimonials')">Testimonial</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('blog')">Blog</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('contact')" class="nav-cta">CONSULENZA</a></li>
-    </ul>
-    <div class="hamburger" id="hamburger">
-        <span></span><span></span><span></span>
-    </div>
-</nav>
-
-<div class="mobile-menu" id="mobileMenu">
-    <ul class="mobile-menu-links">
         <li>
-            <div class="mobile-dropdown-toggle" onclick="toggleMobileSubmenu(this)"><span>Chi Siamo</span></div>
-            <ul class="mobile-submenu">
-                <li><a href="javascript:void(0)" onclick="scrollToSection('mission');closeMobileMenu()">Missione</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('vision');closeMobileMenu()">Visione</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('values');closeMobileMenu()">Valori</a></li>
-            </ul>
+          <a href="javascript:void(0)" onclick="scrollToSection('services')"
+            >Servizi</a
+          >
         </li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('services');closeMobileMenu()">Servizi</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('team');closeMobileMenu()">Team</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('testimonials');closeMobileMenu()">Testimonial</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('blog');closeMobileMenu()">Blog</a></li>
-        <li><a href="javascript:void(0)" onclick="scrollToSection('contact');closeMobileMenu()" class="nav-cta">CONSULENZA</a></li>
-    </ul>
-    <div class="mobile-menu-contacts">
+        <li>
+          <a href="javascript:void(0)" onclick="scrollToSection('team')"
+            >Team</a
+          >
+        </li>
+        <li>
+          <a href="javascript:void(0)" onclick="scrollToSection('testimonials')"
+            >Testimonial</a
+          >
+        </li>
+        <li>
+          <a href="javascript:void(0)" onclick="scrollToSection('blog')"
+            >Blog</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0)"
+            onclick="scrollToSection('contact')"
+            class="nav-cta button-glow"
+            >CONSULENZA</a
+          >
+        </li>
+      </ul>
+      <div class="hamburger" id="hamburger">
+        <span> </span>
+        <span> </span>
+        <span> </span>
+      </div>
+    </nav>
+
+    <div class="mobile-menu" id="mobileMenu">
+      <ul class="mobile-menu-links">
+        <li>
+          <div
+            class="mobile-dropdown-toggle"
+            onclick="toggleMobileSubmenu(this)"
+          >
+            <span>Chi Siamo</span>
+          </div>
+          <ul class="mobile-submenu">
+            <li>
+              <a
+                href="javascript:void(0)"
+                onclick="scrollToSection('mission');closeMobileMenu()"
+                >Missione</a
+              >
+            </li>
+            <li>
+              <a
+                href="javascript:void(0)"
+                onclick="scrollToSection('vision');closeMobileMenu()"
+                >Visione</a
+              >
+            </li>
+            <li>
+              <a
+                href="javascript:void(0)"
+                onclick="scrollToSection('values');closeMobileMenu()"
+                >Valori</a
+              >
+            </li>
+          </ul>
+        </li>
+        <li>
+          <a
+            href="javascript:void(0)"
+            onclick="scrollToSection('services');closeMobileMenu()"
+            >Servizi</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0)"
+            onclick="scrollToSection('team');closeMobileMenu()"
+            >Team</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0)"
+            onclick="scrollToSection('testimonials');closeMobileMenu()"
+            >Testimonial</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0)"
+            onclick="scrollToSection('blog');closeMobileMenu()"
+            >Blog</a
+          >
+        </li>
+        <li>
+          <a
+            href="javascript:void(0)"
+            onclick="scrollToSection('contact');closeMobileMenu()"
+            class="nav-cta button-glow"
+            >CONSULENZA</a
+          >
+        </li>
+      </ul>
+      <div class="mobile-menu-contacts">
         <h3>Contatti</h3>
         <p>P.IVA: 10830661210</p>
         <p>Tel: <a href="tel:+393770439955">+39 377 043 9955</a></p>
-        <p>WhatsApp: <a href="https://wa.me/393770439955">+39 377 043 9955</a></p>
-        <p>Email: <a href="mailto:info@digitaltower.it">info@digitaltower.it</a></p>
-        <p>Via Francesca Catone 33<br>80014 Giugliano (NA)</p>
+        <p>
+          WhatsApp: <a href="https://wa.me/393770439955">+39 377 043 9955</a>
+        </p>
+        <p>
+          Email: <a href="mailto:info@digitaltower.it">info@digitaltower.it</a>
+        </p>
+        <p>Via Francesca Catone 33<br />80014 Giugliano (NA)</p>
+      </div>
     </div>
-</div>
 
-<div id="tower3DContainer"></div>
+    <div id="tower3DContainer"></div>
 
-<section class="hero" id="hero">
-    <div class="section-bg"></div>
-    <div class="section-content">
-        <h1 class="hero-title">TRASFORMA LA TUA VISIONE IN SUCCESSO DIGITALE</h1>
-        <p class="section-text">Qui inizia il viaggio che cambierà per sempre il tuo modo di comunicare. Insieme scaleremo la torre del successo digitale, piano dopo piano, verso risultati straordinari che supereranno ogni tua aspettativa.</p>
-        <a href="javascript:void(0)" class="cta-button" onclick="scrollToSection('about')">Inizia il Viaggio</a>
+    <section class="hero" id="hero">
+      <div class="section-content">
+        <h1 class="hero-title">
+          RENDIAMO LA TUA VISIONE UNA REALTÀ TANGIBILE
+        </h1>
+        <p class="section-text">
+          Qui inizia il viaggio che trasforma intuizioni coraggiose in traguardi
+          concreti. Accendiamo risultati che si fanno sentire sul mercato e nel
+          cuore dei tuoi clienti.
+        </p>
+        <a
+          href="javascript:void(0)"
+          class="cta-button"
+          onclick="scrollToSection('about')"
+          >Inizia il Viaggio</a
+        >
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('about')"
+      role="button"
+      aria-label="Scorri verso Chi Siamo"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('about')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="about">
-    <div class="section-bg"></div>
-    <div class="section-content">
+    <section id="about">
+      <div class="section-bg"></div>
+      <div class="section-content">
         <p class="section-subtitle">La Fondazione</p>
         <h2 class="section-title">Chi Siamo</h2>
-        <p class="section-text">Siamo architetti digitali che costruiscono esperienze indimenticabili. Non creiamo semplicemente siti web o campagne: diamo vita a ecosistemi digitali completi che sfidano la gravità, elevando brand e business verso vette mai raggiunte prima.</p>
+        <p class="section-text">
+          Siamo architetti digitali che costruiscono esperienze indimenticabili.
+          Non creiamo semplicemente siti web o campagne: diamo vita a ecosistemi
+          digitali completi che sfidano la gravità, elevando brand e business
+          verso vette mai raggiunte prima.
+        </p>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('mission')"
+      role="button"
+      aria-label="Scorri verso La Missione"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('mission')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="mission">
-    <div class="section-bg"></div>
-    <div class="section-content">
+    <section id="mission">
+      <div class="section-bg"></div>
+      <div class="section-content">
         <p class="section-subtitle">Il Nostro Scopo</p>
         <h2 class="section-title">La Missione</h2>
-        <p class="section-text">Trasformare ogni idea, anche la più audace, in realtà digitali potenti e misurabili attraverso strategie innovative, creative e data-driven. La nostra missione è rendere ogni cliente protagonista del proprio successo, equipaggiandolo con gli strumenti digitali più avanzati e le strategie più efficaci del mercato.</p>
+        <p class="section-text">
+          Trasformare ogni idea, anche la più audace, in realtà digitali potenti
+          e misurabili attraverso strategie innovative, creative e data-driven.
+          La nostra missione è rendere ogni cliente protagonista del proprio
+          successo, equipaggiandolo con gli strumenti digitali più avanzati e le
+          strategie più efficaci del mercato.
+        </p>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('vision')"
+      role="button"
+      aria-label="Scorri verso La Visione"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('vision')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="vision">
-    <div class="section-bg"></div>
-    <div class="section-content">
+    <section id="vision">
+      <div class="section-bg"></div>
+      <div class="section-content">
         <p class="section-subtitle">Dove Stiamo Andando</p>
         <h2 class="section-title">La Visione</h2>
-        <p class="section-text">Diventare il punto di riferimento assoluto per l'eccellenza digitale in Italia, costruendo la torre più alta del panorama digital. Una torre dove ogni piano rappresenta un traguardo raggiunto, ogni finestra una storia di successo, ogni mattone una relazione duratura costruita sulla fiducia e sui risultati concreti.</p>
+        <p class="section-text">
+          Diventare il punto di riferimento assoluto per l'eccellenza digitale
+          in Italia, costruendo la torre più alta del panorama digital. Una
+          torre dove ogni piano rappresenta un traguardo raggiunto, ogni
+          finestra una storia di successo, ogni mattone una relazione duratura
+          costruita sulla fiducia e sui risultati concreti.
+        </p>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('values')"
+      role="button"
+      aria-label="Scorri verso I Nostri Valori"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('values')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="values">
-    <div class="section-bg"></div>
-    <div class="section-content" style="max-width:1200px">
+    <section id="values">
+      <div class="section-bg"></div>
+      <div class="section-content" style="max-width: 1200px">
         <p class="section-subtitle">I Pilastri</p>
         <h2 class="section-title">I Nostri Valori</h2>
-        <p class="section-text">Ogni piano della torre è sostenuto da pilastri incrollabili. Questi valori guidano ogni nostra decisione, ogni progetto, ogni interazione con i clienti.</p>
+        <p class="section-text">
+          Ogni piano della torre è sostenuto da pilastri incrollabili. Questi
+          valori guidano ogni nostra decisione, ogni progetto, ogni interazione
+          con i clienti.
+        </p>
         <div class="slider-container">
-            <div class="slider-wrapper" id="valuesSlider">
-                <div class="vault-card" onclick="toggleVault(this)">
-                    <div class="vault-door">
-                        <div class="vault-front">
-                            <div class="vault-lock">🔒</div>
-                            <h3>Eccellenza</h3>
-                            <p class="vault-hint">CLICCA</p>
-                        </div>
-                        <div class="vault-back">
-                            <div class="vault-icon">⚡</div>
-                            <h3>Eccellenza</h3>
-                            <p>Ogni dettaglio conta. Perfezioniamo ossessivamente ogni elemento per creare esperienze digitali indimenticabili che non solo soddisfano, ma superano brillantemente ogni aspettativa dei nostri clienti.</p>
-                            <a href="#valori-eccellenza" class="vault-cta">Scopri di più</a>
-                        </div>
-                    </div>
+          <div class="slider-wrapper" id="valuesSlider">
+            <article class="vault-card" data-vault-group="values">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock">
+                    <span class="lock-icon" aria-hidden="true">🔒</span>
+                    <span class="vault-unlocked-icon" aria-hidden="true">⚡</span>
+                  </div>
+                  <h3 class="vault-title">Eccellenza</h3>
+                  <p class="vault-prompt">Clicca per scoprire</p>
                 </div>
-                <div class="vault-card" onclick="toggleVault(this)">
-                    <div class="vault-door">
-                        <div class="vault-front">
-                            <div class="vault-lock">🔒</div>
-                            <h3>Innovazione</h3>
-                            <p class="vault-hint">CLICCA</p>
-                        </div>
-                        <div class="vault-back">
-                            <div class="vault-icon">🎯</div>
-                            <h3>Innovazione</h3>
-                            <p>Non seguiamo le tendenze, le creiamo. Siamo pionieri visionari nel mondo digitale, sempre un passo avanti con soluzioni all'avanguardia che ridefiniscono gli standard del settore.</p>
-                            <a href="#valori-innovazione" class="vault-cta">Scopri di più</a>
-                        </div>
-                    </div>
+                <div class="vault-face vault-content">
+                  <button
+                    class="vault-close"
+                    type="button"
+                    aria-label="Chiudi card"
+                  >
+                    ×
+                  </button>
+                  <div class="vault-icon-display" aria-hidden="true">⚡</div>
+                  <h3>Eccellenza</h3>
+                  <p>
+                    Ogni dettaglio conta. Perfezioniamo ossessivamente ogni
+                    elemento per creare esperienze digitali che superano ogni
+                    aspettativa e lasciano un segno indelebile.
+                  </p>
+                  <a href="#valori-eccellenza" class="vault-link">Scopri di più</a>
                 </div>
-                <div class="vault-card" onclick="toggleVault(this)">
-                    <div class="vault-door">
-                        <div class="vault-front">
-                            <div class="vault-lock">🔒</div>
-                            <h3>Partnership</h3>
-                            <p class="vault-hint">CLICCA</p>
-                        </div>
-                        <div class="vault-back">
-                            <div class="vault-icon">🤝</div>
-                            <h3>Partnership</h3>
-                            <p>Il tuo successo è il nostro successo. Non siamo semplici fornitori, ma partner strategici che crescono insieme a te verso nuove vette con collaborazioni autentiche basate sulla fiducia reciproca.</p>
-                            <a href="#valori-partnership" class="vault-cta">Scopri di più</a>
-                        </div>
-                    </div>
+              </div>
+            </article>
+            <article class="vault-card" data-vault-group="values">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock">
+                    <span class="lock-icon" aria-hidden="true">🔒</span>
+                    <span class="vault-unlocked-icon" aria-hidden="true">🎯</span>
+                  </div>
+                  <h3 class="vault-title">Innovazione</h3>
+                  <p class="vault-prompt">Clicca per scoprire</p>
                 </div>
-                <div class="vault-card" onclick="toggleVault(this)">
-                    <div class="vault-door">
-                        <div class="vault-front">
-                            <div class="vault-lock">🔒</div>
-                            <h3>Qualità</h3>
-                            <p class="vault-hint">CLICCA</p>
-                        </div>
-                        <div class="vault-back">
-                            <div class="vault-icon">💎</div>
-                            <h3>Qualità</h3>
-                            <p>Premium è il nostro standard assoluto e innegociabile. Nessun compromesso sulla qualità dei nostri progetti digitali, perché crediamo che l'eccellenza non sia un'opzione, ma una necessità.</p>
-                            <a href="#valori-qualita" class="vault-cta">Scopri di più</a>
-                        </div>
-                    </div>
+                <div class="vault-face vault-content">
+                  <button
+                    class="vault-close"
+                    type="button"
+                    aria-label="Chiudi card"
+                  >
+                    ×
+                  </button>
+                  <div class="vault-icon-display" aria-hidden="true">🎯</div>
+                  <h3>Innovazione</h3>
+                  <p>
+                    Anticipiamo scenari, testiamo nuove tecnologie e
+                    trasformiamo i trend in strategie concrete che fanno
+                    brillare i brand italiani nel mondo.
+                  </p>
+                  <a href="#valori-innovazione" class="vault-link"
+                    >Scopri di più</a
+                  >
                 </div>
+              </div>
+            </article>
+            <article class="vault-card" data-vault-group="values">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock">
+                    <span class="lock-icon" aria-hidden="true">🔒</span>
+                    <span class="vault-unlocked-icon" aria-hidden="true">🤝</span>
+                  </div>
+                  <h3 class="vault-title">Partnership</h3>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button
+                    class="vault-close"
+                    type="button"
+                    aria-label="Chiudi card"
+                  >
+                    ×
+                  </button>
+                  <div class="vault-icon-display" aria-hidden="true">🤝</div>
+                  <h3>Partnership</h3>
+                  <p>
+                    Lavoriamo al tuo fianco con trasparenza e dedizione,
+                    condividendo obiettivi, metriche e conquiste come un'unica
+                    squadra.
+                  </p>
+                  <a href="#valori-partnership" class="vault-link"
+                    >Scopri di più</a
+                  >
+                </div>
+              </div>
+            </article>
+            <article class="vault-card" data-vault-group="values">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock">
+                    <span class="lock-icon" aria-hidden="true">🔒</span>
+                    <span class="vault-unlocked-icon" aria-hidden="true">🏗️</span>
+                  </div>
+                  <h3 class="vault-title">Qualità</h3>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button
+                    class="vault-close"
+                    type="button"
+                    aria-label="Chiudi card"
+                  >
+                    ×
+                  </button>
+                  <div class="vault-icon-display" aria-hidden="true">🏗️</div>
+                  <h3>Qualità</h3>
+                  <p>
+                    Processi certificati, controllo costante e cura artigianale
+                    ci permettono di consegnare risultati solidi e pronti a
+                    scalare.
+                  </p>
+                  <a href="#valori-qualita" class="vault-link">Scopri di più</a>
+                </div>
+              </div>
+            </article>
+          </div>
+          <div class="carousel-nav">
+            <div class="carousel-arrow" onclick="carouselPrev('valuesSlider')">
+              ‹
             </div>
-            <div class="carousel-nav">
-                <div class="carousel-arrow" onclick="carouselPrev('valuesSlider')">‹</div>
-                <div class="carousel-arrow" onclick="carouselNext('valuesSlider')">›</div>
+            <div class="carousel-arrow" onclick="carouselNext('valuesSlider')">
+              ›
             </div>
+          </div>
         </div>
-    </div>
+      </div>
+    </section>
     <div class="scroll-indicator" onclick="scrollToSection('services')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-</section>
 
-<section id="services">
-    <div class="section-bg"></div>
-    <div class="section-content" style="max-width:1200px">
+    <section id="services">
+      <div class="section-bg"></div>
+      <div class="section-content" style="max-width: 1200px">
         <p class="section-subtitle">Cosa Offriamo</p>
         <h2 class="section-title">I Nostri Servizi</h2>
-        <p class="section-text">Soluzioni digitali complete e integrate per trasformare radicalmente la tua presenza online e generare risultati concreti e misurabili.</p>
+        <p class="section-text">
+          Soluzioni digitali complete e integrate per trasformare radicalmente
+          la tua presenza online e generare risultati concreti e misurabili.
+          Ogni strategia è pensata come un abito su misura: studiata,
+          perfezionata, arricchita di dettagli capaci di far vibrare il tuo
+          pubblico e di tradurre le emozioni in azioni misurabili.
+        </p>
         <div class="services-grid">
-            <div class="service-card" onclick="toggleCard(this)">
-                <div class="service-card-inner">
-                    <div class="service-front">
-                        <span class="service-icon">🎨</span>
-                        <h3>Web Design</h3>
-                        <p>Progettiamo siti web user-centric che uniscono estetica moderna e funzionalità avanzata.</p>
-                    </div>
-                    <div class="service-back">
-                        <h3>Web Design Premium</h3>
-                        <p>Dalla progettazione UX/UI strategica alla realizzazione tecnica impeccabile, creiamo piattaforme web responsive, performanti e ottimizzate SEO che convertono visitatori in clienti fedeli e appassionati del tuo brand.</p>
-                        <a href="#servizi-web-design" class="service-cta">Scopri di più</a>
-                    </div>
-                </div>
+          <article class="vault-card" data-vault-group="services">
+            <div class="vault-card-inner">
+              <div class="vault-face vault-locked">
+                <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">🎨</span></div>
+                <h3 class="vault-title">Web Design</h3>
+                <p class="vault-prompt">Clicca per scoprire</p>
+              </div>
+              <div class="vault-face vault-content">
+                <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                <div class="vault-icon-display" aria-hidden="true">🎨</div>
+                <h3>Web Design Premium</h3>
+                <p>Dalla progettazione UX/UI strategica alla realizzazione tecnica impeccabile, creiamo piattaforme responsive e ottimizzate SEO che trasformano i visitatori in clienti fedeli.</p>
+                <a href="#servizi-web-design" class="vault-link">Scopri di più</a>
+              </div>
             </div>
-            <div class="service-card" onclick="toggleCard(this)">
-                <div class="service-card-inner">
-                    <div class="service-front">
-                        <span class="service-icon">✍️</span>
-                        <h3>Creazione Contenuti</h3>
-                        <p>Sviluppiamo strategie di content marketing coinvolgenti per ogni piattaforma digitale.</p>
-                    </div>
-                    <div class="service-back">
-                        <h3>Content Marketing</h3>
-                        <p>Narrazioni autentiche e strategiche per social media, blog aziendali e piattaforme digitali che costruiscono autorità, engagement e connessioni emotive durature con il tuo pubblico target.</p>
-                        <a href="#servizi-contenuti" class="service-cta">Scopri di più</a>
-                    </div>
-                </div>
+          </article>
+          <article class="vault-card" data-vault-group="services">
+            <div class="vault-card-inner">
+              <div class="vault-face vault-locked">
+                <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">✍️</span></div>
+                <h3 class="vault-title">Content Strategy</h3>
+                <p class="vault-prompt">Clicca per scoprire</p>
+              </div>
+              <div class="vault-face vault-content">
+                <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                <div class="vault-icon-display" aria-hidden="true">✍️</div>
+                <h3>Content Marketing</h3>
+                <p>Narrazioni autentiche per social, blog e campagne che costruiscono autorità, engagement e legami emotivi duraturi.</p>
+                <a href="#servizi-contenuti" class="vault-link">Scopri di più</a>
+              </div>
             </div>
-            <div class="service-card" onclick="toggleCard(this)">
-                <div class="service-card-inner">
-                    <div class="service-front">
-                        <span class="service-icon">⚡</span>
-                        <h3>Branding</h3>
-                        <p>Creiamo identità visive potenti e coerenti che distinguono il tuo brand dalla concorrenza.</p>
-                    </div>
-                    <div class="service-back">
-                        <h3>Brand Identity</h3>
-                        <p>Dal logo alla brand identity completa, sviluppiamo l'immagine perfetta per il tuo business: memorabile, distintiva e allineata perfettamente ai valori della tua azienda e alle aspettative del tuo target.</p>
-                        <a href="#servizi-branding" class="service-cta">Scopri di più</a>
-                    </div>
-                </div>
+          </article>
+          <article class="vault-card" data-vault-group="services">
+            <div class="vault-card-inner">
+              <div class="vault-face vault-locked">
+                <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">⚡</span></div>
+                <h3 class="vault-title">Branding</h3>
+                <p class="vault-prompt">Clicca per scoprire</p>
+              </div>
+              <div class="vault-face vault-content">
+                <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                <div class="vault-icon-display" aria-hidden="true">⚡</div>
+                <h3>Brand Identity</h3>
+                <p>Logo, tono di voce e linee guida complete per un'immagine memorabile, distintiva e perfettamente allineata ai tuoi valori.</p>
+                <a href="#servizi-branding" class="vault-link">Scopri di più</a>
+              </div>
             </div>
-            <div class="service-card" onclick="toggleCard(this)">
-                <div class="service-card-inner">
-                    <div class="service-front">
-                        <span class="service-icon">🚀</span>
-                        <h3>Advertising</h3>
-                        <p>Campagne pubblicitarie data-driven su Google Ads, Meta e LinkedIn per massimizzare il ROI.</p>
-                    </div>
-                    <div class="service-back">
-                        <h3>Performance Advertising</h3>
-                        <p>Strategie di performance marketing avanzate che accelerano esponenzialmente la crescita del tuo business online attraverso campagne ottimizzate al centesimo per generare lead qualificati e conversioni.</p>
-                        <a href="#servizi-advertising" class="service-cta">Scopri di più</a>
-                    </div>
-                </div>
+          </article>
+          <article class="vault-card" data-vault-group="services">
+            <div class="vault-card-inner">
+              <div class="vault-face vault-locked">
+                <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">🚀</span></div>
+                <h3 class="vault-title">Advertising</h3>
+                <p class="vault-prompt">Clicca per scoprire</p>
+              </div>
+              <div class="vault-face vault-content">
+                <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                <div class="vault-icon-display" aria-hidden="true">🚀</div>
+                <h3>Performance Advertising</h3>
+                <p>Campagne data-driven su Google, Meta e LinkedIn ottimizzate al centesimo per generare lead qualificati e conversioni costanti.</p>
+                <a href="#servizi-advertising" class="vault-link">Scopri di più</a>
+              </div>
             </div>
-            <div class="service-card" onclick="toggleCard(this)">
-                <div class="service-card-inner">
-                    <div class="service-front">
-                        <span class="service-icon">📊</span>
-                        <h3>SEO</h3>
-                        <p>Ottimizzazione per motori di ricerca con strategie organiche avanzate per traffico qualificato.</p>
-                    </div>
-                    <div class="service-back">
-                        <h3>SEO Strategico</h3>
-                        <p>Portiamo il tuo sito in prima pagina su Google con tecniche SEO white-hat comprovate, audit tecnici approfonditi, ottimizzazione on-page e off-page, link building di qualità e content strategy mirata.</p>
-                        <a href="#servizi-seo" class="service-cta">Scopri di più</a>
-                    </div>
-                </div>
+          </article>
+          <article class="vault-card" data-vault-group="services">
+            <div class="vault-card-inner">
+              <div class="vault-face vault-locked">
+                <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">📊</span></div>
+                <h3 class="vault-title">SEO</h3>
+                <p class="vault-prompt">Clicca per scoprire</p>
+              </div>
+              <div class="vault-face vault-content">
+                <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                <div class="vault-icon-display" aria-hidden="true">📊</div>
+                <h3>SEO Strategico</h3>
+                <p>Audit tecnici, ottimizzazione on e off-page, content mirato e link building di qualità per scalare la SERP con risultati misurabili.</p>
+                <a href="#servizi-seo" class="vault-link">Scopri di più</a>
+              </div>
             </div>
-            <div class="service-card" onclick="toggleCard(this)">
-                <div class="service-card-inner">
-                    <div class="service-front">
-                        <span class="service-icon">📱</span>
-                        <h3>Social Media</h3>
-                        <p>Gestione strategica dei social media per costruire community fedeli e altamente engaged.</p>
-                    </div>
-                    <div class="service-back">
-                        <h3>Social Media Management</h3>
-                        <p>Da Instagram a LinkedIn, creiamo e gestiamo presenza social che generano risultati misurabili: community management, content creation, influencer marketing e strategie di growth organico e paid.</p>
-                        <a href="#servizi-social" class="service-cta">Scopri di più</a>
-                    </div>
-                </div>
+          </article>
+          <article class="vault-card" data-vault-group="services">
+            <div class="vault-card-inner">
+              <div class="vault-face vault-locked">
+                <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">📱</span></div>
+                <h3 class="vault-title">Social Media</h3>
+                <p class="vault-prompt">Clicca per scoprire</p>
+              </div>
+              <div class="vault-face vault-content">
+                <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                <div class="vault-icon-display" aria-hidden="true">📱</div>
+                <h3>Social Media Management</h3>
+                <p>Strategie editoriali, community management e campagne ibride organiche e paid che fanno crescere community fedeli e attive.</p>
+                <a href="#servizi-social" class="vault-link">Scopri di più</a>
+              </div>
             </div>
+          </article>
         </div>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('team')"
+      role="button"
+      aria-label="Scorri verso Il Team"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('team')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
-<section id="team">
-    <div class="section-bg"></div>
-    <div class="section-content" style="max-width:1200px">
+    <section id="team">
+      <div class="section-bg"></div>
+      <div class="section-content" style="max-width: 1200px">
         <p class="section-subtitle">Le Menti</p>
         <h2 class="section-title">Il Nostro Team</h2>
-        <p class="section-text">Professionisti appassionati ed esperti, uniti da una visione comune di eccellenza digitale e dalla determinazione a trasformare ogni progetto in un successo straordinario.</p>
+        <p class="section-text">
+          Professionisti appassionati ed esperti, uniti da una visione comune di
+          eccellenza digitale e dalla determinazione a trasformare ogni progetto
+          in un successo straordinario. Siamo un team orgogliosamente italiano:
+          portiamo in ogni progetto quella combinazione unica di sensibilità,
+          tenacia e cura artigianale che rende ogni collaborazione una storia di
+          crescita condivisa.
+        </p>
         <div class="slider-container">
-            <div class="slider-wrapper" id="teamSlider">
-                <div class="team-card" onclick="toggleCard(this)">
-                    <div class="team-card-inner">
-                        <div class="team-front">
-                            <div class="team-photo"></div>
-                            <div class="team-info">
-                                <h3 class="team-name">Roberto Esposito</h3>
-                                <p class="team-role">CEO & FOUNDER</p>
-                                <p class="team-bio">Visionario con 15+ anni nel digitale, Roberto ha fondato Digital Tower.</p>
-                                <div class="team-social">
-                                    <a href="#" aria-label="LinkedIn"><svg viewBox="0 0 24 24"><path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77z"/></svg></a>
-                                    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24"><path d="M7.8 2h8.4C19.4 2 22 4.6 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8C4.6 22 2 19.4 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2m-.2 2A3.6 3.6 0 0 0 4 7.6v8.8C4 18.39 5.61 20 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6C20 5.61 18.39 4 16.4 4H7.6m9.65 1.5a1.25 1.25 0 0 1 1.25 1.25A1.25 1.25 0 0 1 17.25 8 1.25 1.25 0 0 1 16 6.75a1.25 1.25 0 0 1 1.25-1.25M12 7a5 5 0 0 1 5 5 5 5 0 0 1-5 5 5 5 0 0 1-5-5 5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/></svg></a>
-                                    <a href="#" aria-label="Website"><svg viewBox="0 0 24 24"><path d="M16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2m-5.15 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 0 1-4.33 3.56M14.34 14H9.66c-.1-.66-.16-1.32-.16-2 0-.68.06-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2M12 19.96c-.83-1.2-1.5-2.53-1.91-3.96h3.82c-.41 1.43-1.08 2.76-1.91 3.96M8 8H5.08A7.923 7.923 0 0 1 9.4 4.44C8.8 5.55 8.35 6.75 8 8m-2.92 8H8c.35 1.25.8 2.45 1.4 3.56A8.008 8.008 0 0 1 5.08 16m-.82-2C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2M12 4.03c.83 1.2 1.5 2.54 1.91 3.97h-3.82c.41-1.43 1.08-2.77 1.91-3.97M18.92 8h-2.95a15.65 15.65 0 0 0-1.38-3.56c1.84.63 3.37 1.9 4.33 3.56M12 2C6.47 2 2 6.5 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg></a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="team-back">
-                            <div class="vault-icon">⚡</div>
-                            <h3>Gennaro Silvestri</h3>
-                            <p>Master in gestione operativa con certificazioni PMP e Agile. Gennaro coordina team complessi e progetti multi-milionari con precisione svizzera, garantendo che ogni deadline venga rispettata e ogni obiettivo superato.</p>
-                            <a href="#team-gennaro" class="vault-cta">Scopri di più</a>
-                        </div>
-                    </div>
+          <div class="slider-wrapper" id="teamSlider">
+            <article class="vault-card team-card" data-vault-group="team">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">👤</span></div>
+                  <h3 class="vault-title">Roberto Esposito</h3>
+                  <p class="vault-subtitle">CEO & Founder</p>
+                  <p class="vault-prompt">Clicca per scoprire</p>
                 </div>
-                <div class="team-card" onclick="toggleCard(this)">
-                    <div class="team-card-inner">
-                        <div class="team-front">
-                            <div class="team-photo"></div>
-                            <div class="team-info">
-                                <h3 class="team-name">Laura Bianchi</h3>
-                                <p class="team-role">CREATIVE DIRECTOR</p>
-                                <p class="team-bio">Creatività senza limiti e visione artistica d'avanguardia che trasforma idee in realtà visive.</p>
-                                <div class="team-social">
-                                    <a href="#" aria-label="LinkedIn"><svg viewBox="0 0 24 24"><path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77z"/></svg></a>
-                                    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24"><path d="M7.8 2h8.4C19.4 2 22 4.6 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8C4.6 22 2 19.4 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2m-.2 2A3.6 3.6 0 0 0 4 7.6v8.8C4 18.39 5.61 20 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6C20 5.61 18.39 4 16.4 4H7.6m9.65 1.5a1.25 1.25 0 0 1 1.25 1.25A1.25 1.25 0 0 1 17.25 8 1.25 1.25 0 0 1 16 6.75a1.25 1.25 0 0 1 1.25-1.25M12 7a5 5 0 0 1 5 5 5 5 0 0 1-5 5 5 5 0 0 1-5-5 5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/></svg></a>
-                                    <a href="#" aria-label="Website"><svg viewBox="0 0 24 24"><path d="M16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2m-5.15 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 0 1-4.33 3.56M14.34 14H9.66c-.1-.66-.16-1.32-.16-2 0-.68.06-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2M12 19.96c-.83-1.2-1.5-2.53-1.91-3.96h3.82c-.41 1.43-1.08 2.76-1.91 3.96M8 8H5.08A7.923 7.923 0 0 1 9.4 4.44C8.8 5.55 8.35 6.75 8 8m-2.92 8H8c.35 1.25.8 2.45 1.4 3.56A8.008 8.008 0 0 1 5.08 16m-.82-2C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2M12 4.03c.83 1.2 1.5 2.54 1.91 3.97h-3.82c.41-1.43 1.08-2.77 1.91-3.97M18.92 8h-2.95a15.65 15.65 0 0 0-1.38-3.56c1.84.63 3.37 1.9 4.33 3.56M12 2C6.47 2 2 6.5 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg></a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="team-back">
-                            <div class="vault-icon">🎨</div>
-                            <h3>Laura Bianchi</h3>
-                            <p>Laureata alla Brera e vincitrice di 12 premi internazionali di design. Laura dirige il reparto creativo con un occhio per l'estetica e l'altro per la conversione, creando design che vendono senza urlare.</p>
-                            <a href="#team-laura" class="vault-cta">Scopri di più</a>
-                        </div>
+                <div class="vault-face vault-content">
+                  <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                  <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=600&auto=format&fit=crop&q=80" alt="Ritratto di Roberto Esposito" class="team-photo-full" />
+                  <div class="team-details">
+                    <h3>Roberto Esposito</h3>
+                    <p class="team-role">CEO & Founder</p>
+                    <p>Ha guidato oltre 180 progetti digitali per PMI e brand internazionali. Con empatia e lucidità strategica costruisce percorsi di crescita sostenibile.</p>
+                    <div class="team-social">
+                      <a href="https://www.digitaltower.it/roberto" target="_blank" rel="noopener">Sito web</a>
+                      <a href="https://www.instagram.com/roberto.esposito" target="_blank" rel="noopener">Instagram</a>
+                      <a href="https://www.linkedin.com/in/roberto-esposito" target="_blank" rel="noopener">LinkedIn</a>
                     </div>
+                  </div>
                 </div>
-                <div class="team-card" onclick="toggleCard(this)">
-                    <div class="team-card-inner">
-                        <div class="team-front">
-                            <div class="team-photo"></div>
-                            <div class="team-info">
-                                <h3 class="team-name">Marco Verdi</h3>
-                                <p class="team-role">TECH LEAD</p>
-                                <p class="team-bio">Architetto tecnologico e problem solver che costruisce soluzioni digitali solide e scalabili.</p>
-                                <div class="team-social">
-                                    <a href="#" aria-label="LinkedIn"><svg viewBox="0 0 24 24"><path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77z"/></svg></a>
-                                    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24"><path d="M7.8 2h8.4C19.4 2 22 4.6 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8C4.6 22 2 19.4 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2m-.2 2A3.6 3.6 0 0 0 4 7.6v8.8C4 18.39 5.61 20 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6C20 5.61 18.39 4 16.4 4H7.6m9.65 1.5a1.25 1.25 0 0 1 1.25 1.25A1.25 1.25 0 0 1 17.25 8 1.25 1.25 0 0 1 16 6.75a1.25 1.25 0 0 1 1.25-1.25M12 7a5 5 0 0 1 5 5 5 5 0 0 1-5 5 5 5 0 0 1-5-5 5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/></svg></a>
-                                    <a href="#" aria-label="Website"><svg viewBox="0 0 24 24"><path d="M16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2m-5.15 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 0 1-4.33 3.56M14.34 14H9.66c-.1-.66-.16-1.32-.16-2 0-.68.06-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2M12 19.96c-.83-1.2-1.5-2.53-1.91-3.96h3.82c-.41 1.43-1.08 2.76-1.91 3.96M8 8H5.08A7.923 7.923 0 0 1 9.4 4.44C8.8 5.55 8.35 6.75 8 8m-2.92 8H8c.35 1.25.8 2.45 1.4 3.56A8.008 8.008 0 0 1 5.08 16m-.82-2C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2M12 4.03c.83 1.2 1.5 2.54 1.91 3.97h-3.82c.41-1.43 1.08-2.77 1.91-3.97M18.92 8h-2.95a15.65 15.65 0 0 0-1.38-3.56c1.84.63 3.37 1.9 4.33 3.56M12 2C6.47 2 2 6.5 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg></a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="team-back">
-                            <div class="vault-icon">💻</div>
-                            <h3>Marco Verdi</h3>
-                            <p>Ex Google engineer con competenze full-stack in React, Node.js, Python e cloud infrastructure. Marco costruisce architetture che gestiscono milioni di utenti senza battere ciglio, ottimizzate per performance e sicurezza.</p>
-                            <a href="#team-marco" class="vault-cta">Scopri di più</a>
-                        </div>
+              </div>
+            </article>
+            <article class="vault-card team-card" data-vault-group="team">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">👤</span></div>
+                  <h3 class="vault-title">Laura Bianchi</h3>
+                  <p class="vault-subtitle">Creative Director</p>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                  <img src="https://images.unsplash.com/photo-1521572163474-6864f9cf17ab?w=600&auto=format&fit=crop&q=80" alt="Ritratto di Laura Bianchi" class="team-photo-full" />
+                  <div class="team-details">
+                    <h3>Laura Bianchi</h3>
+                    <p class="team-role">Creative Director</p>
+                    <p>Specialista in experience design per fashion e hospitality, unisce arte e conversione per brand italiani di fascia alta.</p>
+                    <div class="team-social">
+                      <a href="https://www.digitaltower.it/laura" target="_blank" rel="noopener">Sito web</a>
+                      <a href="https://www.instagram.com/laura.bianchi" target="_blank" rel="noopener">Instagram</a>
+                      <a href="https://www.linkedin.com/in/laura-bianchi" target="_blank" rel="noopener">LinkedIn</a>
                     </div>
+                  </div>
                 </div>
-                <div class="team-card" onclick="toggleCard(this)">
-                    <div class="team-card-inner">
-                        <div class="team-front">
-                            <div class="team-photo"></div>
-                            <div class="team-info">
-                                <h3 class="team-name">Sofia Marino</h3>
-                                <p class="team-role">MARKETING DIRECTOR</p>
-                                <p class="team-bio">Stratega di marketing data-driven con track record impressionante nel generare ROI eccezionale.</p>
-                                <div class="team-social">
-                                    <a href="#" aria-label="LinkedIn"><svg viewBox="0 0 24 24"><path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77z"/></svg></a>
-                                    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24"><path d="M7.8 2h8.4C19.4 2 22 4.6 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8C4.6 22 2 19.4 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2m-.2 2A3.6 3.6 0 0 0 4 7.6v8.8C4 18.39 5.61 20 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6C20 5.61 18.39 4 16.4 4H7.6m9.65 1.5a1.25 1.25 0 0 1 1.25 1.25A1.25 1.25 0 0 1 17.25 8 1.25 1.25 0 0 1 16 6.75a1.25 1.25 0 0 1 1.25-1.25M12 7a5 5 0 0 1 5 5 5 5 0 0 1-5 5 5 5 0 0 1-5-5 5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/></svg></a>
-                                    <a href="#" aria-label="Website"><svg viewBox="0 0 24 24"><path d="M16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2m-5.15 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 0 1-4.33 3.56M14.34 14H9.66c-.1-.66-.16-1.32-.16-2 0-.68.06-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2M12 19.96c-.83-1.2-1.5-2.53-1.91-3.96h3.82c-.41 1.43-1.08 2.76-1.91 3.96M8 8H5.08A7.923 7.923 0 0 1 9.4 4.44C8.8 5.55 8.35 6.75 8 8m-2.92 8H8c.35 1.25.8 2.45 1.4 3.56A8.008 8.008 0 0 1 5.08 16m-.82-2C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2M12 4.03c.83 1.2 1.5 2.54 1.91 3.97h-3.82c.41-1.43 1.08-2.77 1.91-3.97M18.92 8h-2.95a15.65 15.65 0 0 0-1.38-3.56c1.84.63 3.37 1.9 4.33 3.56M12 2C6.47 2 2 6.5 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg></a>
-                                </div>
-                            </div>
-                        </div>
-                        <div class="team-back">
-                            <div class="vault-icon">📊</div>
-                            <h3>Sofia Marino</h3>
-                            <p>Certificata Google Ads, Meta Blueprint e HubSpot. Sofia ha generato oltre 50M€ di revenue per i clienti negli ultimi 3 anni attraverso campagne di marketing chirurgicamente precise e costantemente ottimizzate.</p>
-                            <a href="#team-sofia" class="vault-cta">Scopri di più</a>
-                        </div>
+              </div>
+            </article>
+            <article class="vault-card team-card" data-vault-group="team">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">👤</span></div>
+                  <h3 class="vault-title">Marco Verdi</h3>
+                  <p class="vault-subtitle">Tech Lead</p>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                  <img src="https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=600&auto=format&fit=crop&q=80" alt="Ritratto di Marco Verdi" class="team-photo-full" />
+                  <div class="team-details">
+                    <h3>Marco Verdi</h3>
+                    <p class="team-role">Tech Lead</p>
+                    <p>Coordina team di sviluppo full stack, integra stack headless e soluzioni cloud per garantire scalabilità e tempi di caricamento record.</p>
+                    <div class="team-social">
+                      <a href="https://www.digitaltower.it/marco" target="_blank" rel="noopener">Sito web</a>
+                      <a href="https://www.instagram.com/marco.verdi" target="_blank" rel="noopener">Instagram</a>
+                      <a href="https://www.linkedin.com/in/marco-verdi" target="_blank" rel="noopener">LinkedIn</a>
                     </div>
+                  </div>
                 </div>
+              </div>
+            </article>
+            <article class="vault-card team-card" data-vault-group="team">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">👤</span></div>
+                  <h3 class="vault-title">Giulia Contini</h3>
+                  <p class="vault-subtitle">UX Strategist</p>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                  <img src="https://images.unsplash.com/photo-1524503033411-c9566986fc8f?w=600&auto=format&fit=crop&q=80" alt="Ritratto di Giulia Contini" class="team-photo-full" />
+                  <div class="team-details">
+                    <h3>Giulia Contini</h3>
+                    <p class="team-role">UX Strategist</p>
+                    <p>Ha condotto oltre 300 sessioni di user research: trasforma dati comportamentali in journey digitali inclusivi e ad altissimo tasso di conversione.</p>
+                    <div class="team-social">
+                      <a href="https://www.digitaltower.it/giulia" target="_blank" rel="noopener">Sito web</a>
+                      <a href="https://www.instagram.com/giulia.contini" target="_blank" rel="noopener">Instagram</a>
+                      <a href="https://www.linkedin.com/in/giulia-contini" target="_blank" rel="noopener">LinkedIn</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </article>
+            <article class="vault-card team-card" data-vault-group="team">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">👤</span></div>
+                  <h3 class="vault-title">Alessandro Rinaldi</h3>
+                  <p class="vault-subtitle">Head of Data & AI</p>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                  <img src="https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=600&auto=format&fit=crop&q=80" alt="Ritratto di Alessandro Rinaldi" class="team-photo-full" />
+                  <div class="team-details">
+                    <h3>Alessandro Rinaldi</h3>
+                    <p class="team-role">Head of Data & AI</p>
+                    <p>Ex data scientist nel fintech, oggi sviluppa dashboard predittive e automazioni AI che ottimizzano campagne e funnel in tempo reale.</p>
+                    <div class="team-social">
+                      <a href="https://www.digitaltower.it/alessandro" target="_blank" rel="noopener">Sito web</a>
+                      <a href="https://www.instagram.com/alessandro.rinaldi" target="_blank" rel="noopener">Instagram</a>
+                      <a href="https://www.linkedin.com/in/alessandro-rinaldi" target="_blank" rel="noopener">LinkedIn</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </article>
+            <article class="vault-card team-card" data-vault-group="team">
+              <div class="vault-card-inner">
+                <div class="vault-face vault-locked">
+                  <div class="vault-lock"><span class="lock-icon" aria-hidden="true">🔒</span><span class="vault-unlocked-icon" aria-hidden="true">👤</span></div>
+                  <h3 class="vault-title">Sofia Martelli</h3>
+                  <p class="vault-subtitle">Digital PR & Partnerships</p>
+                  <p class="vault-prompt">Clicca per scoprire</p>
+                </div>
+                <div class="vault-face vault-content">
+                  <button class="vault-close" type="button" aria-label="Chiudi card">×</button>
+                  <img src="https://images.unsplash.com/photo-1544723795-4325370ad0da?w=600&auto=format&fit=crop&q=80" alt="Ritratto di Sofia Martelli" class="team-photo-full" />
+                  <div class="team-details">
+                    <h3>Sofia Martelli</h3>
+                    <p class="team-role">Digital PR & Partnerships</p>
+                    <p>Coordina collaborazioni con media, creator e stakeholder strategici, generando coperture stampa e partnership ad alto impatto.</p>
+                    <div class="team-social">
+                      <a href="https://www.digitaltower.it/sofia" target="_blank" rel="noopener">Sito web</a>
+                      <a href="https://www.instagram.com/sofia.martelli" target="_blank" rel="noopener">Instagram</a>
+                      <a href="https://www.linkedin.com/in/sofia-martelli" target="_blank" rel="noopener">LinkedIn</a>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </article>
+          </div>
+          <div class="carousel-nav">
+            <div class="carousel-arrow" onclick="carouselPrev('teamSlider')">
+              ‹
             </div>
-            <div class="carousel-nav">
-                <div class="carousel-arrow" onclick="carouselPrev('teamSlider')">‹</div>
-                <div class="carousel-arrow" onclick="carouselNext('teamSlider')">›</div>
+            <div class="carousel-arrow" onclick="carouselNext('teamSlider')">
+              ›
             </div>
+          </div>
         </div>
         <div class="team-join">
-            <a href="#carriere">Unisciti al Team →</a>
+          <a href="#carriere" class="cta-button">Unisciti al Team</a>
         </div>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('testimonials')"
+      role="button"
+      aria-label="Scorri verso le Testimonianze"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('testimonials')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="testimonials">
-    <div class="section-bg"></div>
-    <div class="section-content" style="max-width:1200px">
+    <section id="testimonials">
+      <div class="section-bg"></div>
+      <div class="section-content" style="max-width: 1200px">
         <p class="section-subtitle">Voci del Successo</p>
         <h2 class="section-title">Cosa Dicono</h2>
-        <p class="section-text">Le testimonianze dei nostri clienti raccontano storie autentiche di trasformazione, crescita e successo condiviso.</p>
+        <p class="section-text">
+          Le testimonianze dei nostri clienti raccontano storie autentiche di
+          trasformazione, crescita e successo condiviso. Ogni parola è una
+          promessa mantenuta, un risultato misurabile e un'emozione che continua
+          a risuonare molto tempo dopo la consegna del progetto.
+        </p>
         <div class="slider-container">
-            <div class="slider-wrapper" id="testimonialsSlider">
-                <div class="testimonial-card" onclick="toggleCard(this)">
-                    <div class="testimonial-card-inner">
-                        <div class="testimonial-front">
-                            <div class="testimonial-image"></div>
-                            <p class="testimonial-text">"Team eccezionale che lavora come un'estensione naturale della nostra azienda. Comunicazione impeccabile e attenzione maniacale ai dettagli."</p>
-                            <p class="testimonial-author">Francesca Palmieri</p>
-                            <p class="testimonial-company">Wellness Space | Fitness & Benessere | Bari</p>
-                        </div>
-                        <div class="testimonial-back">
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white)">Hanno gestito il rebranding completo del nostro centro, dal logo al sito, dai social alle campagne. Risultato: +420% di iscrizioni in 6 mesi e lista d'attesa costante.</p>
-                        </div>
-                    </div>
-                </div>
+          <div class="slider-wrapper testimonials-slider" id="testimonialsSlider">
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1542596594-649edbc13630?w=200&auto=format&fit=crop&q=80" alt="ritratto di Chiara Romano" class="testimonial-photo" />
+              <blockquote>“La loro strategia digitale ha raddoppiato il tasso di conversione in tre mesi: ci hanno guidati con cura sartoriale.”</blockquote>
+              <p class="testimonial-name">Chiara Romano</p>
+              <p class="testimonial-meta">Co-founder · Atelier Aurora · Milano</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?w=200&auto=format&fit=crop&q=80" alt="ritratto di Lorenzo De Luca" class="testimonial-photo" />
+              <blockquote>“Un partner affidabile che unisce creatività e numeri: ora il nostro e-commerce parla davvero ai clienti giusti.”</blockquote>
+              <p class="testimonial-name">Lorenzo De Luca</p>
+              <p class="testimonial-meta">CEO · Vinitaly Boutique · Verona</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1525130413817-d45c1d127c42?w=200&auto=format&fit=crop&q=80" alt="ritratto di Marta Valenti" class="testimonial-photo" />
+              <blockquote>“Hanno riposizionato il brand e lanciato campagne memorabili. Le vendite in boutique sono salite del 48%.”</blockquote>
+              <p class="testimonial-name">Marta Valenti</p>
+              <p class="testimonial-meta">Marketing Manager · Maison Valenti · Firenze</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1504593811423-6dd665756598?w=200&auto=format&fit=crop&q=80" alt="ritratto di Davide Perri" class="testimonial-photo" />
+              <blockquote>“Approccio data-driven impeccabile: grazie alle dashboard in tempo reale abbiamo decisioni rapide e condivise.”</blockquote>
+              <p class="testimonial-name">Davide Perri</p>
+              <p class="testimonial-meta">COO · NextLab Tech · Torino</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=200&auto=format&fit=crop&q=80" alt="ritratto di Elisa Moretti" class="testimonial-photo" />
+              <blockquote>“Dal sito alla content strategy, tutto comunica la nostra anima artigiana. I clienti ce lo riconoscono ogni giorno.”</blockquote>
+              <p class="testimonial-name">Elisa Moretti</p>
+              <p class="testimonial-meta">Founder · Moretti Ceramiche · Faenza</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=200&auto=format&fit=crop&q=80" alt="ritratto di Francesco Leone" class="testimonial-photo" />
+              <blockquote>“Abbiamo conquistato nuovi mercati esteri con campagne su misura e storytelling emozionante.”</blockquote>
+              <p class="testimonial-name">Francesco Leone</p>
+              <p class="testimonial-meta">Export Manager · Leone Caffè · Napoli</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1554151228-14d9def656e4?w=200&auto=format&fit=crop&q=80" alt="ritratto di Serena Ruggeri" class="testimonial-photo" />
+              <blockquote>“Il rebranding è stato rivoluzionario ma rispettoso delle nostre radici. Feedback entusiasti da clienti e partner.”</blockquote>
+              <p class="testimonial-name">Serena Ruggeri</p>
+              <p class="testimonial-meta">Direttrice · Studio Ruggeri · Bologna</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1522071820081-009f0129c71c?w=200&auto=format&fit=crop&q=80" alt="ritratto di Tommaso Greco" class="testimonial-photo" />
+              <blockquote>“La consulenza continua ci permette di evolvere senza timori: sono il nostro faro nel mare digitale.”</blockquote>
+              <p class="testimonial-name">Tommaso Greco</p>
+              <p class="testimonial-meta">Founder · Greco Consulting · Roma</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1524504388940-b1c1722653e1?w=200&auto=format&fit=crop&q=80" alt="ritratto di Irene Salvatori" class="testimonial-photo" />
+              <blockquote>“Team attento, disponibile, concreto. Abbiamo ridotto il costo lead del 36% mantenendo alta la qualità.”</blockquote>
+              <p class="testimonial-name">Irene Salvatori</p>
+              <p class="testimonial-meta">CMO · Salvatori Travel · Genova</p>
+            </article>
+            <article class="testimonial-card">
+              <img src="https://images.unsplash.com/photo-1522506209496-4536d9020ec2?w=200&auto=format&fit=crop&q=80" alt="ritratto di Gabriele Fontana" class="testimonial-photo" />
+              <blockquote>“Ogni meeting è un concentrato di idee pratiche. I risultati parlano: +62% di fatturato online in un anno.”</blockquote>
+              <p class="testimonial-name">Gabriele Fontana</p>
+              <p class="testimonial-meta">Amministratore · Fontana Arredo · Bergamo</p>
+            </article>
+          </div>
+          <div class="carousel-nav">
+            <div class="carousel-arrow" onclick="carouselPrev('testimonialsSlider')">
+              ‹
             </div>
-            <div class="carousel-nav">
-                <div class="carousel-arrow" onclick="carouselPrev('testimonialsSlider')">‹</div>
-                <div class="carousel-arrow" onclick="carouselNext('testimonialsSlider')">›</div>
+            <div class="carousel-arrow" onclick="carouselNext('testimonialsSlider')">
+              ›
             </div>
+          </div>
         </div>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('blog')"
+      role="button"
+      aria-label="Scorri verso il Blog"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('blog')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="blog">
-    <div class="section-bg"></div>
-    <div class="section-content" style="max-width:1200px">
+    <section id="blog">
+      <div class="section-bg"></div>
+      <div class="section-content" style="max-width: 1200px">
         <p class="section-subtitle">Insights</p>
         <h2 class="section-title">Dal Nostro Blog</h2>
-        <p class="section-text">Riflessioni strategiche, trend emergenti e case study approfonditi dal mondo del marketing digitale contemporaneo.</p>
+        <p class="section-text">
+          Riflessioni strategiche, trend emergenti e case study approfonditi dal
+          mondo del marketing digitale contemporaneo. Ogni articolo è pensato
+          per offrirti ispirazione immediata e strumenti pratici da applicare
+          subito, senza fronzoli, con la forza delle idee che funzionano davvero.
+        </p>
         <div class="slider-container">
-            <div class="slider-wrapper" id="blogSlider">
-                <div class="blog-card" onclick="toggleCard(this)">
-                    <div class="blog-card-inner">
-                        <div class="blog-front">
-                            <div class="blog-image"></div>
-                            <div class="blog-content">
-                                <p class="blog-date">10 Gen 2025</p>
-                                <h3 class="blog-title">Il Futuro del Web Design</h3>
-                                <p class="blog-subtitle">Tendenze 2025</p>
-                                <p class="blog-excerpt">AI, design immersivo e UX personalizzata definiscono il futuro.</p>
-                            </div>
-                        </div>
-                        <div class="blog-back">
-                            <h3>Il Futuro del Web Design</h3>
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white);margin-bottom:1.5rem">Scopri come l'intelligenza artificiale, il design 3D e l'ultra-personalizzazione stanno ridefinendo gli standard del web design moderno e cosa significa per il tuo business.</p>
-                            <a href="#blog-web-design" class="vault-cta">Leggi l'articolo</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="blog-card" onclick="toggleCard(this)">
-                    <div class="blog-card-inner">
-                        <div class="blog-front">
-                            <div class="blog-image"></div>
-                            <div class="blog-content">
-                                <p class="blog-date">05 Gen 2025</p>
-                                <h3 class="blog-title">Brand Premium</h3>
-                                <p class="blog-subtitle">Guida Completa</p>
-                                <p class="blog-excerpt">Come costruire identità di marca che conquistano il mercato.</p>
-                            </div>
-                        </div>
-                        <div class="blog-back">
-                            <h3>Costruire un Brand Premium</h3>
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white);margin-bottom:1.5rem">Le strategie concrete utilizzate dai brand di lusso per creare percezioni di valore premium e giustificare prezzi superiori alla concorrenza.</p>
-                            <a href="#blog-brand" class="vault-cta">Leggi l'articolo</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="blog-card" onclick="toggleCard(this)">
-                    <div class="blog-card-inner">
-                        <div class="blog-front">
-                            <div class="blog-image"></div>
-                            <div class="blog-content">
-                                <p class="blog-date">28 Dic 2024</p>
-                                <h3 class="blog-title">SEO Avanzato</h3>
-                                <p class="blog-subtitle">Strategie Vincenti</p>
-                                <p class="blog-excerpt">Domina i motori di ricerca con tecniche all'avanguardia.</p>
-                            </div>
-                        </div>
-                        <div class="blog-back">
-                            <h3>SEO Avanzato 2025</h3>
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white);margin-bottom:1.5rem">Tecniche SEO avanzate che funzionano davvero: dall'ottimizzazione Core Web Vitals alla strategia di contenuti che Google premia con ranking superiori.</p>
-                            <a href="#blog-seo" class="vault-cta">Leggi l'articolo</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="blog-card" onclick="toggleCard(this)">
-                    <div class="blog-card-inner">
-                        <div class="blog-front">
-                            <div class="blog-image"></div>
-                            <div class="blog-content">
-                                <p class="blog-date">20 Dic 2024</p>
-                                <h3 class="blog-title">E-Commerce 2025</h3>
-                                <p class="blog-subtitle">Massimizza Vendite</p>
-                                <p class="blog-excerpt">Aumenta il tasso di conversione con strategie provate.</p>
-                            </div>
-                        </div>
-                        <div class="blog-back">
-                            <h3>E-Commerce che Converte</h3>
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white);margin-bottom:1.5rem">Case study reale: come abbiamo aumentato il conversion rate dal 1.2% al 4.8% ottimizzando checkout, UX e strategia di pricing psicologico.</p>
-                            <a href="#blog-ecommerce" class="vault-cta">Leggi l'articolo</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="blog-card" onclick="toggleCard(this)">
-                    <div class="blog-card-inner">
-                        <div class="blog-front">
-                            <div class="blog-image"></div>
-                            <div class="blog-content">
-                                <p class="blog-date">15 Dic 2024</p>
-                                <h3 class="blog-title">Social Media Marketing</h3>
-                                <p class="blog-subtitle">Engagement Perfetto</p>
-                                <p class="blog-excerpt">Costruisci community autentiche e fedeli al tuo brand.</p>
-                            </div>
-                        </div>
-                        <div class="blog-back">
-                            <h3>Social Media che Funziona</h3>
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white);margin-bottom:1.5rem">La formula esatta per creare contenuti virali organici, costruire community engaged e trasformare follower in clienti paganti senza budget pubblicitari enormi.</p>
-                            <a href="#blog-social" class="vault-cta">Leggi l'articolo</a>
-                        </div>
-                    </div>
-                </div>
-                <div class="blog-card" onclick="toggleCard(this)">
-                    <div class="blog-card-inner">
-                        <div class="blog-front">
-                            <div class="blog-image"></div>
-                            <div class="blog-content">
-                                <p class="blog-date">08 Dic 2024</p>
-                                <h3 class="blog-title">Content Marketing</h3>
-                                <p class="blog-subtitle">Storytelling Efficace</p>
-                                <p class="blog-excerpt">Crea narrazioni che convertono e fidelizzano i clienti.</p>
-                            </div>
-                        </div>
-                        <div class="blog-back">
-                            <h3>Storytelling che Vende</h3>
-                            <p style="font-size:.9rem;line-height:1.7;color:var(--white);margin-bottom:1.5rem">Come utilizzare le neuroscienze del storytelling per creare contenuti che generano connessioni emotive profonde e decisioni d'acquisto immediate.</p>
-                            <a href="#blog-content" class="vault-cta">Leggi l'articolo</a>
-                        </div>
-                    </div>
-                </div>
+          <div class="slider-wrapper blog-slider" id="blogSlider">
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1521572267360-ee0c2909d518?w=800&auto=format&fit=crop&q=80" alt="Brand Storytelling che Converte" /></div>
+              <div class="blog-body">
+                <h3>Brand Storytelling che Converte</h3>
+                <p>Tecniche narrative per dare voce al tuo brand e guidare l'utente verso l'azione.</p>
+                <a href="#blog-storytelling" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1517430816045-df4b7de11d1d?w=800&auto=format&fit=crop&q=80" alt="UX Writing per eCommerce" /></div>
+              <div class="blog-body">
+                <h3>UX Writing per eCommerce</h3>
+                <p>Microcopy e percorsi persuasivi per ridurre l'abbandono del carrello.</p>
+                <a href="#blog-ux" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1500530855697-b586d89ba3ee?w=800&auto=format&fit=crop&q=80" alt="SEO Locale per PMI" /></div>
+              <div class="blog-body">
+                <h3>SEO Locale per PMI</h3>
+                <p>Strategie pratiche per dominare le ricerche vicino a te e generare visite in store.</p>
+                <a href="#blog-seo" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1520607162513-77705c0f0d4a?w=800&auto=format&fit=crop&q=80" alt="Performance Ads 2025" /></div>
+              <div class="blog-body">
+                <h3>Performance Ads 2025</h3>
+                <p>Budget smart e creatività dinamiche per campagne ad alto impatto.</p>
+                <a href="#blog-ads" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1521791055366-0d553872125f?w=800&auto=format&fit=crop&q=80" alt="AI nel Marketing" /></div>
+              <div class="blog-body">
+                <h3>AI nel Marketing</h3>
+                <p>Workflow intelligenti che liberano tempo al tuo team e aumentano il ROI.</p>
+                <a href="#blog-ai" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1545239351-1141bd82e8a6?w=800&auto=format&fit=crop&q=80" alt="Social Commerce" /></div>
+              <div class="blog-body">
+                <h3>Social Commerce</h3>
+                <p>Come trasformare Instagram e TikTok in canali di vendita diretta.</p>
+                <a href="#blog-social" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1474631245212-32dc3c8310c6?w=800&auto=format&fit=crop&q=80" alt="Email Journey Memorabili" /></div>
+              <div class="blog-body">
+                <h3>Email Journey Memorabili</h3>
+                <p>Automazioni che nutrono la relazione con il cliente e aumentano il valore medio.</p>
+                <a href="#blog-email" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1454165205744-3b78555e5572?w=800&auto=format&fit=crop&q=80" alt="Metriche da Monitorare" /></div>
+              <div class="blog-body">
+                <h3>Metriche da Monitorare</h3>
+                <p>I KPI essenziali per valutare ogni progetto digitale con lucidità.</p>
+                <a href="#blog-metriche" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1521737604893-d14cc237f11d?w=800&auto=format&fit=crop&q=80" alt="Customer Journey Omnicanale" /></div>
+              <div class="blog-body">
+                <h3>Customer Journey Omnicanale</h3>
+                <p>Integrare online e offline per esperienze coerenti e memorabili.</p>
+                <a href="#blog-journey" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+            <article class="blog-card">
+              <div class="blog-thumb"><img src="https://images.unsplash.com/photo-1498050108023-c5249f4df085?w=800&auto=format&fit=crop&q=80" alt="Rebranding Senza Stress" /></div>
+              <div class="blog-body">
+                <h3>Rebranding Senza Stress</h3>
+                <p>Checklist completa per rilanciare l'immagine aziendale senza perdere riconoscibilità.</p>
+                <a href="#blog-rebranding" class="blog-link">Visualizza articolo</a>
+              </div>
+            </article>
+          </div>
+          <div class="carousel-nav">
+            <div class="carousel-arrow" onclick="carouselPrev('blogSlider')">
+              ‹
             </div>
-            <div class="carousel-nav">
-                <div class="carousel-arrow" onclick="carouselPrev('blogSlider')">‹</div>
-                <div class="carousel-arrow" onclick="carouselNext('blogSlider')">›</div>
+            <div class="carousel-arrow" onclick="carouselNext('blogSlider')">
+              ›
             </div>
+          </div>
         </div>
+      </div>
+    </section>
+    <div
+      class="scroll-indicator"
+      onclick="scrollToSection('contact')"
+      role="button"
+      aria-label="Scorri verso i Contatti"
+    >
+      <span class="scroll-text">Scroll</span>
+      <div class="scroll-icon"></div>
     </div>
-    <div class="scroll-indicator" onclick="scrollToSection('contact')">
-        <span class="scroll-text">Scroll</span>
-        <div class="scroll-icon"></div>
-    </div>
-</section>
 
-<section id="contact">
-    <div class="section-bg"></div>
-    <div class="section-content">
+    <section id="contact">
+      <div class="section-bg"></div>
+      <div class="section-content">
         <p class="section-subtitle">La Cima</p>
         <h2 class="section-title">Raggiungiamo la Vetta Insieme</h2>
-        <p class="section-text">Sei pronto a trasformare la tua visione in realtà? Contattaci ora per una consulenza strategica gratuita e inizia il viaggio verso il successo digitale che meriti.</p>
+        <p class="section-text">
+          Sei pronto a trasformare la tua visione in realtà? Contattaci ora per
+          una consulenza strategica gratuita e inizia il viaggio verso il
+          successo digitale che meriti. Ogni progetto che affidiamo al nostro
+          team viene seguito con dedizione, ascolto e responsabilità: saliamo
+          insieme fino alla cima, passo dopo passo, senza mai lasciarti solo.
+        </p>
         <form class="contact-form" id="contactForm">
-            <div class="form-row">
-                <div class="form-group">
-                    <input type="text" class="form-input" name="nome" placeholder="Nome" required>
-                </div>
-                <div class="form-group">
-                    <input type="email" class="form-input" name="email" placeholder="Email" required>
-                </div>
+          <div class="form-row">
+            <div class="form-group">
+              <input
+                type="text"
+                class="form-input"
+                name="nome"
+                placeholder="Nome"
+                required
+              />
             </div>
-            <div class="form-row">
-                <div class="form-group">
-                    <input type="tel" class="form-input" name="telefono" placeholder="Telefono" required>
-                </div>
-                <div class="form-group">
-                    <input type="text" class="form-input" name="azienda" placeholder="Azienda">
-                </div>
+            <div class="form-group">
+              <input
+                type="email"
+                class="form-input"
+                name="email"
+                placeholder="Email"
+                required
+              />
             </div>
-            <div class="form-row">
-                <div class="form-group">
-                    <select class="form-select" name="budget" required>
-                        <option value="">Budget</option>
-                        <option value="<5k">< €5k</option>
-                        <option value="5-10k">€5-10k</option>
-                        <option value="10-20k">€10-20k</option>
-                        <option value=">20k">> €20k</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <select class="form-select" name="settore" required>
-                        <option value="">Settore</option>
-                        <option value="retail">Retail</option>
-                        <option value="tech">Tech</option>
-                        <option value="fashion">Fashion</option>
-                        <option value="hospitality">Hospitality</option>
-                        <option value="altro">Altro</option>
-                    </select>
-                </div>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <input
+                type="tel"
+                class="form-input"
+                name="telefono"
+                placeholder="Telefono"
+                required
+              />
             </div>
-            <div class="form-group full-width">
-                <textarea class="form-textarea" name="messaggio" placeholder="Raccontaci del tuo progetto e dei tuoi obiettivi" required></textarea>
+            <div class="form-group">
+              <input
+                type="text"
+                class="form-input"
+                name="azienda"
+                placeholder="Azienda"
+              />
             </div>
-            <button type="submit" class="form-submit">Inizia Ora</button>
+          </div>
+          <div class="form-row">
+            <div class="form-group">
+              <select class="form-select" name="budget" required>
+                <option value="">Budget</option>
+                <option value="<5k">< €5k</option>
+                <option value="5-10k">€5-10k</option>
+                <option value="10-20k">€10-20k</option>
+                <option value=">20k">> €20k</option>
+              </select>
+            </div>
+            <div class="form-group">
+              <select class="form-select" name="settore" required>
+                <option value="">Settore</option>
+                <option value="retail">Retail</option>
+                <option value="tech">Tech</option>
+                <option value="fashion">Fashion</option>
+                <option value="hospitality">Hospitality</option>
+                <option value="altro">Altro</option>
+              </select>
+            </div>
+          </div>
+          <div class="form-group full-width">
+            <textarea
+              class="form-textarea"
+              name="messaggio"
+              placeholder="Raccontaci del tuo progetto e dei tuoi obiettivi"
+              required
+            ></textarea>
+          </div>
+          <button type="submit" class="form-submit">Inizia Ora</button>
         </form>
-    </div>
-</section>
+      </div>
+    </section>
 
-<footer>
-    <div class="sub-footer">
+    <footer>
+      <div class="sub-footer">
         <div class="footer-section">
-            <h3>DIGITAL TOWER</h3>
-            <p class="footer-bio">Agenzia digitale di marketing e comunicazione a Napoli, ma operante in tutta Italia, specializzata in web design innovativo, branding distintivo, creazione contenuti coinvolgenti per social media e strategie di marketing digitale data-driven che generano risultati concreti e misurabili.</p>
+          <h3>DIGITAL TOWER</h3>
+          <p class="footer-bio">
+            Agenzia digitale di marketing e comunicazione a Napoli, ma operante
+            in tutta Italia, specializzata in web design innovativo, branding
+            distintivo, creazione contenuti coinvolgenti per social media e
+            strategie di marketing digitale data-driven che generano risultati
+            concreti e misurabili.
+          </p>
         </div>
         <div class="footer-section">
-            <h3>Menu</h3>
-            <ul class="footer-menu">
-                <li><a href="javascript:void(0)" onclick="scrollToSection('about')">Chi Siamo</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('services')">Servizi</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('team')">Team</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('blog')">Blog</a></li>
-                <li><a href="javascript:void(0)" onclick="scrollToSection('contact')">Contatti</a></li>
-            </ul>
+          <h3>Menu</h3>
+          <ul class="footer-menu">
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('about')"
+                >Chi Siamo</a
+              >
+            </li>
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('services')"
+                >Servizi</a
+              >
+            </li>
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('team')"
+                >Team</a
+              >
+            </li>
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('blog')"
+                >Blog</a
+              >
+            </li>
+            <li>
+              <a href="javascript:void(0)" onclick="scrollToSection('contact')"
+                >Contatti</a
+              >
+            </li>
+          </ul>
         </div>
         <div class="footer-section">
-            <h3>Contatti</h3>
-            <div class="footer-contact">
-                <p>P.IVA: 10830661210</p>
-                <p>Tel: <a href="tel:+393770439955">+39 377 043 9955</a></p>
-                <p>Email: <a href="mailto:info@digitaltower.it">info@digitaltower.it</a></p>
-                <p>Via Francesca Catone 33<br>80014 Giugliano (NA)</p>
-            </div>
+          <h3>Contatti</h3>
+          <div class="footer-contact">
+            <p>P.IVA: 10830661210</p>
+            <p>Tel: <a href="tel:+393770439955">+39 377 043 9955</a></p>
+            <p>
+              Email:
+              <a href="mailto:info@digitaltower.it">info@digitaltower.it</a>
+            </p>
+            <p>Via Francesca Catone 33<br />80014 Giugliano (NA)</p>
+          </div>
         </div>
         <div class="footer-section">
-            <h3>Newsletter</h3>
-            <p class="footer-bio" style="margin-bottom:1rem">Iscriviti per ricevere insights esclusivi e strategie digitali avanzate.</p>
-            <form class="newsletter-form">
-                <input type="email" class="newsletter-input" placeholder="La tua email" required>
-                <button type="submit" class="newsletter-btn">Iscriviti</button>
-            </form>
+          <h3>Newsletter</h3>
+          <p class="footer-bio" style="margin-bottom: 1rem">
+            Iscriviti per ricevere insights esclusivi e strategie digitali
+            avanzate.
+          </p>
+          <form class="newsletter-form">
+            <input
+              type="email"
+              class="newsletter-input"
+              placeholder="La tua email"
+              required
+            />
+            <button type="submit" class="newsletter-btn button-glow">
+              Iscriviti
+            </button>
+          </form>
         </div>
-    </div>
-    <div class="footer-bottom">
-        <p class="footer-text">© 2025 Digital Tower - Scaliamo insieme la torre del successo</p>
+      </div>
+      <div class="footer-bottom">
+        <p class="footer-text">
+          © 2025 Digital Tower - Scaliamo insieme la torre del successo
+        </p>
         <div class="footer-links">
-            <a href="#">Privacy Policy</a>
-            <a href="#">Termini e Condizioni</a>
+          <a href="#">Privacy Policy</a>
+          <a href="#">Termini e Condizioni</a>
         </div>
-    </div>
-</footer>
+      </div>
+    </footer>
 
-<script>
-    const text="SCALIAMO INSIEME LA TORRE DEL SUCCESSO",loaderText=document.getElementById('loaderText');text.split('').forEach((c,i)=>{const s=document.createElement('span');s.textContent=c===' '?'\u00A0':c;s.style.setProperty('--i',i);s.style.animationDelay=`${i*.05}s`;loaderText.appendChild(s)});
-
-    let progress=0,scene,camera,renderer,towerGroup,isScrolling=!1,hasScrolled=!1;
-    const loaderBar=document.getElementById('loaderBar'),loader=document.getElementById('loader'),mainNav=document.getElementById('mainNav'),tower3DContainer=document.getElementById('tower3DContainer'),progressBar=document.getElementById('progressBar'),progressBarContainer=document.getElementById('progressBarContainer'),lightGlow1=document.getElementById('lightGlow1'),lightGlow2=document.getElementById('lightGlow2'),cardOverlay=document.getElementById('cardOverlay');
-
-    const loadInt=setInterval(()=>{progress+=8*Math.random(),progress>100&&(progress=100),loaderBar.style.width=progress+'%',100===progress&&(clearInterval(loadInt),setTimeout(()=>{loader.classList.add('hidden'),setTimeout(()=>{mainNav.classList.add('visible'),init3DScene(),initSections(),initParticles(),setTimeout(()=>{lightGlow1.classList.add('active'),lightGlow2.classList.add('active')},500)},200)},600))},160);
-
-    function init3DScene(){if(!window.THREE)return;scene=new THREE.Scene(),camera=new THREE.PerspectiveCamera(45,window.innerWidth/window.innerHeight,.1,1e3),camera.position.set(0,8,45),renderer=new THREE.WebGLRenderer({alpha:!0,antialias:!0}),renderer.setSize(window.innerWidth,window.innerHeight),renderer.setPixelRatio(Math.min(window.devicePixelRatio,2)),tower3DContainer.appendChild(renderer.domElement);const ambientLight=new THREE.AmbientLight(16777215,.5);scene.add(ambientLight);const pointLight1=new THREE.PointLight(14329087,1.2,80);pointLight1.position.set(5,25,10),scene.add(pointLight1);const pointLight2=new THREE.PointLight(16766773,.8,60);pointLight2.position.set(-5,15,5),scene.add(pointLight2);towerGroup=new THREE.Group();const levels=25,baseWidth=3.5,topWidth=.6;for(let i=0;i<levels;i++){const t=i/levels,width=baseWidth-(baseWidth-topWidth)*t,height=1.8,depth=width*.7,floorGeometry=new THREE.BoxGeometry(width,height,depth),material=new THREE.MeshPhongMaterial({color:i%2===0?14329087:16766773,transparent:!0,opacity:.75,shininess:120,emissive:i%3===0?14329087:0,emissiveIntensity:.4}),floor=new THREE.Mesh(floorGeometry,material);floor.position.y=i*2,towerGroup.add(floor);if(i%2===0){const windowGeometry=new THREE.BoxGeometry(width*.15,.6,depth*1.01),windowMaterial=new THREE.MeshBasicMaterial({color:16776960,transparent:!0,opacity:.9,emissive:16776960,emissiveIntensity:1}),positions=[-.3,0,.3];positions.forEach(x=>{const win=new THREE.Mesh(windowGeometry,windowMaterial);win.position.set(x*width,i*2,0),towerGroup.add(win)})}}const spireGeometry=new THREE.ConeGeometry(topWidth,4,8),spireMaterial=new THREE.MeshPhongMaterial({color:16766773,emissive:16766773,emissiveIntensity:.8,shininess:150}),spire=new THREE.Mesh(spireGeometry,spireMaterial);spire.position.y=levels*2+2,towerGroup.add(spire);const topGlowGeometry=new THREE.SphereGeometry(.6,16,16),topGlowMaterial=new THREE.MeshBasicMaterial({color:16766773,transparent:!0,opacity:.7}),topGlow=new THREE.Mesh(topGlowGeometry,topGlowMaterial);topGlow.position.y=levels*2+4,towerGroup.add(topGlow),scene.add(towerGroup),animate3D()}
-
-    function animate3D(){requestAnimationFrame(animate3D);const scrollY=window.scrollY,maxScroll=document.documentElement.scrollHeight-window.innerHeight,scrollProgress=Math.min(scrollY/maxScroll,1);const startY=8,endY=52,startZ=45,endZ=8,targetY=startY+(endY-startY)*Math.pow(scrollProgress,1.2),targetZ=startZ+(endZ-startZ)*Math.pow(scrollProgress,.8),targetRotation=scrollProgress*Math.PI*6;camera.position.y+=(targetY-camera.position.y)*.1,camera.position.z+=(targetZ-camera.position.z)*.1;const angle=targetRotation,radius=18-scrollProgress*10;camera.position.x=Math.sin(angle)*radius*.4,camera.lookAt(0,targetY-5,0),towerGroup&&(towerGroup.rotation.y+=.002),renderer.render(scene,camera)}
-
-    window.addEventListener('resize',()=>{camera&&renderer&&(camera.aspect=window.innerWidth/window.innerHeight,camera.updateProjectionMatrix(),renderer.setSize(window.innerWidth,window.innerHeight))},{passive:!0});
-
-    const canvas=document.getElementById('particleCanvas'),ctx=canvas.getContext('2d');function initCanvas(){canvas.width=window.innerWidth,canvas.height=window.innerHeight}let particles=[],mouse={x:-999,y:-999};function initParticles(){initCanvas(),particles=[];const count=window.innerWidth<768?40:70;for(let i=0;i<count;i++)particles.push(new Particle);animateParticles()}class Particle{constructor(){this.reset()}reset(){this.x=Math.random()*canvas.width,this.y=Math.random()*canvas.height,this.size=Math.random()*2+1,this.speedX=(Math.random()-.5)*.3,this.speedY=(Math.random()-.5)*.3,this.opacity=Math.random()*.4+.3,this.baseX=this.x,this.baseY=this.y,this.color=Math.random()>.5?'212,175,55':'255,107,53'}update(){const dx=mouse.x-this.x,dy=mouse.y-this.y,dist=Math.sqrt(dx*dx+dy*dy);if(dist<100){const force=(100-dist)/100,angle=Math.atan2(dy,dx);this.x-=Math.cos(angle)*force*3,this.y-=Math.sin(angle)*force*3}else this.x+=(this.baseX-this.x)*.03,this.y+=(this.baseY-this.y)*.03;this.baseX+=this.speedX,this.baseY+=this.speedY,(this.baseX<0||this.baseX>canvas.width)&&(this.speedX*=-1),(this.baseY<0||this.baseY>canvas.height)&&(this.speedY*=-1)}draw(){ctx.fillStyle=`rgba(${this.color},${this.opacity})`,ctx.shadowBlur=8,ctx.shadowColor=`rgba(${this.color},0.8)`,ctx.beginPath(),ctx.arc(this.x,this.y,this.size,0,2*Math.PI),ctx.fill()}}function animateParticles(){ctx.clearRect(0,0,canvas.width,canvas.height),particles.forEach(p=>{p.update(),p.draw()}),requestAnimationFrame(animateParticles)}
-
-    if(window.innerWidth>1024){const cursor=document.querySelector('.cursor'),follower=document.querySelector('.cursor-follower');let mouseX=-50,mouseY=-50,cursorX=-50,cursorY=-50,followerX=-50,followerY=-50,raf;document.addEventListener('mousemove',e=>{mouseX=e.clientX,mouseY=e.clientY,raf||(raf=requestAnimationFrame(updateCursor))},{passive:!0});function updateCursor(){cursorX+=(mouseX-cursorX)*.12,cursorY+=(mouseY-cursorY)*.12,followerX+=(mouseX-followerX)*.06,followerY+=(mouseY-followerY)*.06,cursor.style.transform=`translate(${cursorX-6}px,${cursorY-6}px)`,follower.style.transform=`translate(${followerX-25}px,${followerY-25}px)`,raf=requestAnimationFrame(updateCursor)}updateCursor(),document.querySelectorAll('a, button, .vault-card, .cta-button, .form-submit, .service-card, .team-card, .testimonial-card, .blog-card, .carousel-arrow').forEach(el=>{el.addEventListener('mouseenter',()=>{cursor.style.transform+=' scale(2.2)',follower.style.transform+=' scale(1.8)'}),el.addEventListener('mouseleave',()=>{cursor.style.transform=cursor.style.transform.replace(' scale(2.2)',''),follower.style.transform=follower.style.transform.replace(' scale(1.8)','')})})}
-
-    document.addEventListener('mousemove',e=>{mouse.x=e.clientX,mouse.y=e.clientY},{passive:!0}),window.addEventListener('resize',()=>{initCanvas(),particles.forEach(p=>p.reset())},{passive:!0});
-
-    function toggleVault(card){const isOpen=card.classList.contains('flipped'),allCards=document.querySelectorAll('.vault-card, .service-card, .team-card, .testimonial-card, .blog-card');if(isOpen){card.classList.remove('flipped'),cardOverlay.classList.remove('active'),document.querySelector('.slider-wrapper').parentElement.classList.remove('cards-dimmed'),document.body.style.overflow=''}else{allCards.forEach(c=>c.classList.remove('flipped')),card.classList.add('flipped'),cardOverlay.classList.add('active'),card.closest('.slider-wrapper').parentElement.classList.add('cards-dimmed'),document.body.style.overflow='hidden'}}
-
-    function toggleCard(card){toggleVault(card)}
-
-    cardOverlay.addEventListener('click',()=>{document.querySelectorAll('.vault-card, .service-card, .team-card, .testimonial-card, .blog-card').forEach(c=>c.classList.remove('flipped')),cardOverlay.classList.remove('active'),document.querySelectorAll('.slider-container').forEach(c=>c.classList.remove('cards-dimmed')),document.body.style.overflow=''});
-
-    const hamburger=document.getElementById('hamburger'),mobileMenu=document.getElementById('mobileMenu');function closeMobileMenu(){hamburger?.classList.remove('active'),mobileMenu?.classList.remove('active'),document.body.style.overflow=''}function toggleMobileSubmenu(el){el.classList.toggle('active');const submenu=el.nextElementSibling;submenu&&submenu.classList.toggle('active')}hamburger?.addEventListener('click',()=>{hamburger.classList.toggle('active'),mobileMenu.classList.toggle('active'),document.body.style.overflow=mobileMenu.classList.contains('active')?'hidden':''});
-
-    const sections=Array.from(document.querySelectorAll('section'));function initSections(){sections[0]&&sections[0].classList.add('visible'),updateSections()}
-
-    let lastSection=null;function updateProgressBar(){const scrollY=window.scrollY,footer=document.querySelector('footer');if(!hasScrolled&&scrollY>50){hasScrolled=!0,progressBarContainer.classList.add('visible')}if(!hasScrolled)return;const navHeight=mainNav.getBoundingClientRect().height,footerTop=footer?(footer.getBoundingClientRect().top+scrollY):document.documentElement.scrollHeight,maxHeight=footerTop-navHeight-80,docHeight=document.documentElement.scrollHeight-window.innerHeight,scrollPercent=Math.max(0,Math.min(1,scrollY/docHeight));progressBar.style.height=`${scrollPercent*maxHeight}px`;let currentSection=null;sections.forEach(s=>{const rect=s.getBoundingClientRect(),center=rect.top+rect.height*.5;center>0&&center<window.innerHeight&&(currentSection=s)});if(currentSection&&currentSection!==lastSection){lastSection=currentSection,progressBar.classList.add('section-pulse'),setTimeout(()=>{progressBar.classList.remove('section-pulse')},800)}}
-
-    function updateSections(){updateProgressBar(),sections.forEach(section=>{const rect=section.getBoundingClientRect(),visibleHeight=Math.max(0,Math.min(window.innerHeight,rect.top+rect.height)-Math.max(0,rect.top)),visibleRatio=visibleHeight/window.innerHeight;visibleRatio>.3?section.classList.add('visible'):section.classList.remove('visible')})}
-
-    function scrollToSection(id){const section=document.getElementById(id);if(section){const offset=section.getBoundingClientRect().top+window.pageYOffset-100;window.scrollTo({top:offset,behavior:'smooth'})}closeMobileMenu()}
-
-    function carouselNext(id){const slider=document.getElementById(id);if(slider){const card=slider.querySelector('.vault-card, .testimonial-card, .blog-card, .team-card');card&&slider.scrollBy({left:card.offsetWidth+32,behavior:'smooth'})}}
-
-    function carouselPrev(id){const slider=document.getElementById(id);if(slider){const card=slider.querySelector('.vault-card, .testimonial-card, .blog-card, .team-card');card&&slider.scrollBy({left:-(card.offsetWidth+32),behavior:'smooth'})}}
-
-    window.addEventListener('scroll',()=>{isScrolling||(window.requestAnimationFrame(()=>{updateSections(),isScrolling=!1}),isScrolling=!0),window.scrollY>80?mainNav.classList.add('scrolled'):mainNav.classList.remove('scrolled')},{passive:!0}),window.addEventListener('resize',()=>{updateSections()},{passive:!0});
-
-    const contactForm=document.getElementById('contactForm');contactForm?.addEventListener('submit',e=>{e.preventDefault();const submitBtn=e.target.querySelector('.form-submit'),originalText=submitBtn.textContent;submitBtn.textContent='Invio...',submitBtn.disabled=!0,setTimeout(()=>{const modal=document.createElement('div');modal.style.cssText='position:fixed;top:50%;left:50%;transform:translate(-50%,-50%);background:linear-gradient(135deg,rgba(13,27,42,0.98),rgba(10,14,20,1));border:2px solid var(--orange);padding:2.5rem;border-radius:10px;text-align:center;z-index:10000;box-shadow:0 20px 60px rgba(0,0,0,.9),0 0 40px rgba(255,107,53,.5)',modal.innerHTML='<h3 style="color:var(--gold);margin-bottom:1rem;font-size:1.5rem;text-shadow:0 0 20px rgba(255,107,53,.6)">Grazie!</h3><p style="color:var(--white);margin-bottom:1.5rem">Ti contatteremo presto.</p><button onclick="this.parentElement.remove()" style="background:linear-gradient(135deg,var(--orange),var(--gold));color:#000;border:none;padding:0.8rem 1.5rem;border-radius:4px;cursor:pointer;font-weight:bold;box-shadow:0 4px 15px rgba(255,107,53,.5)">OK</button>',document.body.appendChild(modal),e.target.reset(),submitBtn.textContent=originalText,submitBtn.disabled=!1,setTimeout(()=>{modal.parentElement&&modal.remove()},3e3)},1500)})
-</script>
-</body>
-</html>ial-image"></div>
-<p class="testimonial-text">"In 8 mesi il nostro fatturato online è cresciuto del 340%. Digital Tower non ha solo rifatto il sito, ha rivoluzionato tutto il nostro approccio digitale."</p>
-<p class="testimonial-author">Davide Santangelo</p>
-<p class="testimonial-company">Santangelo Gioielli | Oreficeria | Napoli</p>
-</div>
-<div class="testimonial-back">
-    <p style="font-size:.9rem;line-height:1.7;color:var(--white)">Prima di Digital Tower avevamo un sito vetrina che non convertiva. Ora abbiamo un e-commerce che vende h24, una presenza social che ci porta clienti ogni giorno e campagne Google che generano ROI del 580%.</p>
-</div>
-</div>
-</div>
-<div class="testimonial-card" onclick="toggleCard(this)">
-    <div class="testimonial-card-inner">
-        <div class="testimonial-front">
-            <div class="testimonial-image"></div>
-            <p class="testimonial-text">"La strategia di Digital Tower ci ha permesso di aprire 3 nuovi punti vendita in 18 mesi. Risultati che parlano da soli."</p>
-            <p class="testimonial-author">Caterina Lombardi</p>
-            <p class="testimonial-company">Atelier Lombardi | Moda Alta Gamma | Milano</p>
-        </div>
-        <div class="testimonial-back">
-            <p style="font-size:.9rem;line-height:1.7;color:var(--white)">Professionalità assoluta. Hanno capito immediatamente il nostro target luxury e creato un brand digitale all'altezza delle nostre aspettative. I lead qualificati sono triplicati.</p>
-        </div>
-    </div>
-</div>
-<div class="testimonial-card" onclick="toggleCard(this)">
-    <div class="testimonial-card-inner">
-        <div class="testimonial-front">
-            <div class="testimonial-image"></div>
-            <p class="testimonial-text">"Il miglior investimento degli ultimi 5 anni. Il loro approccio data-driven ha trasformato completamente i nostri numeri."</p>
-            <p class="testimonial-author">Alessandro Ferrante</p>
-            <p class="testimonial-company">Ferrante Tech Solutions | IT Services | Roma</p>
-        </div>
-        <div class="testimonial-back">
-            <p style="font-size:.9rem;line-height:1.7;color:var(--white)">Passati da 15 lead al mese a 180, con un tasso di conversione del 23%. Il sito è velocissimo, la SEO funziona perfettamente e le campagne PPC sono ottimizzate settimanalmente.</p>
-        </div>
-    </div>
-</div>
-<div class="testimonial-card" onclick="toggleCard(this)">
-    <div class="testimonial-card-inner">
-        <div class="testimonial-front">
-            <div class="testimonial-image"></div>
-            <p class="testimonial-text">"Non solo un'agenzia, un vero partner strategico. Sono sempre disponibili, propositivi e orientati ai risultati concreti."</p>
-            <p class="testimonial-author">Valentina Esposito</p>
-            <p class="testimonial-company">Villa Vittoria | Hospitality | Sorrento</p>
-        </div>
-        <div class="testimonial-back">
-            <p style="font-size:.9rem;line-height:1.7;color:var(--white)">Abbiamo aumentato le prenotazioni dirette del 250%, riducendo la dipendenza dalle OTA. Il sito è stupendo, veloce e converte benissimo. La gestione social è impeccabile.</p>
-        </div>
-    </div>
-</div>
-<div class="testimonial-card" onclick="toggleCard(this)">
-    <div class="testimonial-card-inner">
-        <div class="testimonial-front">
-            <div class="testimonial-image"></div>
-            <p class="testimonial-text">"Finalmente un'agenzia che mantiene le promesse. Ogni euro investito si è moltiplicato per 6. Numeri reali, non chiacchiere."</p>
-            <p class="testimonial-author">Gennaro Rizzo</p>
-            <p class="testimonial-company">Rizzo & Partners | Studio Legale | Salerno</p>
-        </div>
-        <div class="testimonial-back">
-            <p style="font-size:.9rem;line-height:1.7;color:var(--white)">Hanno costruito il nostro posizionamento digitale da zero. Oggi siamo primi su Google per 47 keyword strategiche e riceviamo 8-12 richieste qualificate a settimana.</p>
-        </div>
-    </div>
-</div>
-<div class="testimonial-card" onclick="toggleCard(this)">
-    <div class="testimonial-card-inner">
-        <div class="testimonial-front">
-            <div class="testimon5 2 12a10 10 0 0 0 10 10 10 10 0 0 0 10-10A10 10 0 0 0 12 2z"/></svg></a>
-        </div>
-    </div>
-</div>
-<div class="team-back">
-    <div class="vault-icon">🎯</div>
-    <h3>Roberto Esposito</h3>
-    <p>Con oltre 15 anni di esperienza nel marketing digitale, Roberto ha guidato la trasformazione digitale di oltre 200 aziende. La sua visione strategica e la sua capacità di anticipare le tendenze del mercato hanno reso Digital Tower un punto di riferimento nel settore.</p>
-    <a href="#team-roberto" class="vault-cta">Scopri di più</a>
-</div>
-</div>
-</div>
-<div class="team-card" onclick="toggleCard(this)">
-    <div class="team-card-inner">
-        <div class="team-front">
-            <div class="team-photo"></div>
-            <div class="team-info">
-                <h3 class="team-name">Gennaro Silvestri</h3>
-                <p class="team-role">COO & CO-FOUNDER</p>
-                <p class="team-bio">Esperto di strategie operative e project management, Gennaro trasforma visioni in risultati.</p>
-                <div class="team-social">
-                    <a href="#" aria-label="LinkedIn"><svg viewBox="0 0 24 24"><path d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h14m-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93h2.79M6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37h2.77z"/></svg></a>
-                    <a href="#" aria-label="Instagram"><svg viewBox="0 0 24 24"><path d="M7.8 2h8.4C19.4 2 22 4.6 22 7.8v8.4a5.8 5.8 0 0 1-5.8 5.8H7.8C4.6 22 2 19.4 2 16.2V7.8A5.8 5.8 0 0 1 7.8 2m-.2 2A3.6 3.6 0 0 0 4 7.6v8.8C4 18.39 5.61 20 7.6 20h8.8a3.6 3.6 0 0 0 3.6-3.6V7.6C20 5.61 18.39 4 16.4 4H7.6m9.65 1.5a1.25 1.25 0 0 1 1.25 1.25A1.25 1.25 0 0 1 17.25 8 1.25 1.25 0 0 1 16 6.75a1.25 1.25 0 0 1 1.25-1.25M12 7a5 5 0 0 1 5 5 5 5 0 0 1-5 5 5 5 0 0 1-5-5 5 5 0 0 1 5-5m0 2a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3z"/></svg></a>
-                    <a href="#" aria-label="Website"><svg viewBox="0 0 24 24"><path d="M16.36 14c.08-.66.14-1.32.14-2 0-.68-.06-1.34-.14-2h3.38c.16.64.26 1.31.26 2s-.1 1.36-.26 2m-5.15 5.56c.6-1.11 1.06-2.31 1.38-3.56h2.95a8.03 8.03 0 0 1-4.33 3.56M14.34 14H9.66c-.1-.66-.16-1.32-.16-2 0-.68.06-1.35.16-2h4.68c.09.65.16 1.32.16 2 0 .68-.07 1.34-.16 2M12 19.96c-.83-1.2-1.5-2.53-1.91-3.96h3.82c-.41 1.43-1.08 2.76-1.91 3.96M8 8H5.08A7.923 7.923 0 0 1 9.4 4.44C8.8 5.55 8.35 6.75 8 8m-2.92 8H8c.35 1.25.8 2.45 1.4 3.56A8.008 8.008 0 0 1 5.08 16m-.82-2C4.1 13.36 4 12.69 4 12s.1-1.36.26-2h3.38c-.08.66-.14 1.32-.14 2 0 .68.06 1.34.14 2M12 4.03c.83 1.2 1.5 2.54 1.91 3.97h-3.82c.41-1.43 1.08-2.77 1.91-3.97M18.92 8h-2.95a15.65 15.65 0 0 0-1.38-3.56c1.84.63 3.37 1.9 4.33 3.56M12 2C6.47 2 2 6.<!DOCTYPE html><html lang="it"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1,user-scalable=no"><meta name="description" content="Digital Tower - Agenzia digitale di marketing e comunicazione a Napoli. Trasformiamo la tua visione in successo digitale attraverso web design innovativo, branding distintivo, contenuti coinvolgenti e strategie di marketing data-driven che generano risultati concreti e misurabili."><meta name="keywords" content="web design Napoli, agenzia digitale Napoli, branding Napoli, marketing digitale, sviluppo web, SEO Italia, social media marketing, content marketing, web agency Napoli, digital marketing Italia"><meta name="theme-color" content="#d4af37"><meta property="og:title" content="Digital Tower - Trasforma la Tua Visione in Successo Digitale"><meta property="og:description" content="Agenzia digitale specializzata in web design, branding e strategie digitali che generano risultati concreti"><meta property="og:type" content="website"><link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin><link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@300;400;600;800;900&display=swap" rel="stylesheet"><script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js" defer></script><title>Digital Tower - Scaliamo Insieme la Torre del Successo</title><style>
-                        :root{--black:#0a0e14;--dark-teal:#0d1b2a;--gold:#d4af37;--gold-light:#ffd700;--gold-dark:#9a7c1f;--amber:#ffbf00;--orange:#ff6b35;--teal:#4a9b8e;--cyan:#64dfdf;--white:#e8eaed;--white-dim:#94a3b8;--left:clamp(24px,8vw,120px)}
-                        *{margin:0;padding:0;box-sizing:border-box;-webkit-tap-highlight-color:transparent}
-                        html{scroll-behavior:smooth;overflow-x:hidden}
-                        body{font-family:Montserrat,sans-serif;background:#000;color:var(--white);overflow-x:hidden;cursor:none;-webkit-font-smoothing:antialiased}
-                        @media(max-width:1024px){body{cursor:auto}}
-                        .loader{position:fixed;inset:0;background:radial-gradient(ellipse at 50% 20%,rgba(255,183,0,.08),transparent 60%),radial-gradient(ellipse at 50% 80%,rgba(255,107,53,.06),transparent 70%),#0a0e14;display:flex;flex-direction:column;align-items:center;justify-content:center;z-index:10000;transition:opacity .8s,visibility .8s}
-                        .loader.hidden{opacity:0;visibility:hidden;pointer-events:none}
-                        .loader-tower{width:min(200px,40vw);height:auto;margin-bottom:2rem;filter:drop-shadow(0 10px 30px rgba(212,175,55,.3))}
-                        .loader-tower path,.loader-tower rect,.loader-tower polygon{stroke-dasharray:var(--len);stroke-dashoffset:var(--len);animation:drawPath 2s ease-out forwards}
-                        @keyframes drawPath{to{stroke-dashoffset:0}}
-                        .loader-text{font-size:clamp(1rem,3vw,1.5rem);font-weight:800;letter-spacing:.25em;color:var(--gold);margin-bottom:2rem;text-transform:uppercase;text-shadow:0 0 20px rgba(212,175,55,.5)}
-                        .loader-text span{display:inline-block;opacity:0;animation:fadeIn .5s forwards;animation-delay:calc(var(--i) * .05s)}
-                        @keyframes fadeIn{to{opacity:1}}
-                        .loader-bar-wrap{width:min(350px,80vw);height:4px;background:rgba(212,175,55,.15);border-radius:4px;overflow:hidden}
-                        .loader-bar{height:100%;background:linear-gradient(90deg,#9a7c1f,#d4af37,#ffbf00,#ffd700);width:0;transition:width .3s;box-shadow:0 0 20px rgba(212,175,55,.8)}
-                        .carbon-fiber{position:fixed;top:0;left:0;width:100%;height:100%;z-index:0;opacity:.12;background-image:repeating-linear-gradient(0deg,transparent,transparent 2px,rgba(74,155,142,.2)2px,rgba(74,155,142,.2)4px),repeating-linear-gradient(90deg,transparent,transparent 2px,rgba(255,107,53,.12)2px,rgba(255,107,53,.12)4px);background-size:6px 6px;pointer-events:none}
-                        .vignette{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:3;background:radial-gradient(ellipse at center,transparent 15%,rgba(10,14,20,.85)85%)}
-                        .cursor,.cursor-follower{border-radius:50%;position:fixed;pointer-events:none;z-index:9999;mix-blend-mode:difference;will-change:transform;top:-50px;left:-50px}
-                        .cursor{width:12px;height:12px;border:2px solid var(--gold);transition:transform .15s;box-shadow:0 0 10px rgba(212,175,55,.6)}
-                        .cursor-follower{width:50px;height:50px;border:1px solid rgba(212,175,55,.4);z-index:9998;transition:transform .3s}
-                        nav{position:fixed;top:0;left:0;width:100%;padding:1.5rem 5%;display:flex;justify-content:space-between;align-items:center;z-index:1000;opacity:0;transition:opacity 2s ease 2s,background .3s;backdrop-filter:blur(20px);border-bottom:1px solid rgba(74,155,142,.15)}
-                        nav.visible{opacity:1}
-                        nav.scrolled{background:rgba(10,14,20,.85);box-shadow:0 4px 30px rgba(0,0,0,.9),0 0 15px rgba(255,107,53,.1)}
-                        .nav-logo{font-size:1.5rem;font-weight:900;letter-spacing:.1em;background:linear-gradient(135deg,#ffd700,#ff6b35,#d4af37);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;cursor:pointer;transition:all .3s;filter:drop-shadow(0 0 10px rgba(212,175,55,.3))}
-                        .nav-logo:hover{transform:scale(1.05);filter:drop-shadow(0 0 15px rgba(255,107,53,.6))}
-                        .nav-menu{display:flex;gap:2rem;list-style:none;align-items:center}
-                        .nav-menu>li{position:relative}
-                        .nav-menu a{color:var(--white-dim);text-decoration:none;font-size:.8rem;text-transform:uppercase;letter-spacing:.15em;font-weight:600;transition:all .3s;padding:.5rem 0;display:block;position:relative}
-                        .nav-menu a::after{content:'';position:absolute;bottom:0;left:0;width:0;height:2px;background:linear-gradient(90deg,var(--orange),var(--gold));transition:width .3s}
-                        .nav-menu a:hover{color:var(--gold)}
-                        .nav-menu a:hover::after{width:100%}
-                        .nav-cta{background:linear-gradient(135deg,#ff6b35,#ffbf00)!important;color:#000!important;padding:.8rem 1.8rem!important;border-radius:4px;font-weight:800;position:relative;overflow:hidden}
-                        .nav-cta::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,#ff6b35,#ffbf00);opacity:.6;filter:blur(15px);z-index:-1;animation:ctaPulse 2s ease-in-out infinite}
-                        @keyframes ctaPulse{0%,100%{transform:scale(1);opacity:.6}50%{transform:scale(1.1);opacity:.8}}
-                        .nav-cta::after{display:none}
-                        .nav-dropdown{position:relative}
-                        .nav-dropdown>a{display:flex;align-items:center;gap:.5rem}
-                        .nav-dropdown>a::before{content:'▸';font-size:.9rem;transition:transform .3s}
-                        .nav-dropdown:hover>a::before{transform:rotate(90deg)}
-                        .nav-dropdown-menu{position:absolute;top:100%;left:0;background:rgba(10,14,20,.98);backdrop-filter:blur(20px);border:1px solid rgba(74,155,142,.3);border-radius:8px;padding:1rem 0;min-width:200px;opacity:0;visibility:hidden;transform:translateY(-10px);transition:all .3s;box-shadow:0 10px 40px rgba(0,0,0,.7),0 0 15px rgba(255,107,53,.15);list-style:none}
-                        .nav-dropdown:hover .nav-dropdown-menu{opacity:1;visibility:visible;transform:translateY(0)}
-                        .nav-dropdown-menu a{padding:.8rem 1.5rem;font-size:.75rem}
-                        .nav-dropdown-menu a:hover{background:rgba(255,107,53,.1)}
-                        .hamburger{display:flex;flex-direction:column;gap:5px;cursor:pointer;z-index:1001;width:30px;height:25px;position:relative;transition:transform .4s}
-                        .hamburger span{width:100%;height:2px;background:var(--gold);transition:all .4s;border-radius:2px;transform-origin:center;box-shadow:0 0 5px rgba(212,175,55,.4)}
-                        .hamburger.active{transform:rotate(180deg)}
-                        .hamburger.active span:nth-child(1){transform:rotate(45deg)translate(5px,5px)}
-                        .hamburger.active span:nth-child(2){opacity:0;transform:translateX(-10px)}
-                        .hamburger.active span:nth-child(3){transform:rotate(-45deg)translate(7px,-6px)}
-                        .mobile-menu{position:fixed;top:0;right:-100%;width:100%;max-width:400px;height:100vh;background:linear-gradient(135deg,rgba(10,14,20,.98),rgba(13,27,42,.98));backdrop-filter:blur(30px);z-index:999;padding:6rem 2rem 2rem;transition:right .5s;overflow-y:auto;box-shadow:-5px 0 30px rgba(0,0,0,.7);border-left:1px solid rgba(74,155,142,.3)}
-                        .mobile-menu.active{right:0}
-                        .mobile-menu-links{list-style:none;margin-bottom:2rem}
-                        .mobile-menu-links>li{margin-bottom:.5rem}
-                        .mobile-menu-links a{color:var(--white);text-decoration:none;font-size:1.1rem;text-transform:uppercase;letter-spacing:.15em;font-weight:600;padding:1rem;display:block;border-left:3px solid transparent;transition:all .3s;position:relative;font-family:Montserrat,sans-serif}
-                        .mobile-menu-links a::before{content:'';position:absolute;left:0;top:0;width:0;height:100%;background:rgba(255,107,53,.08);transition:width .3s;z-index:-1}
-                        .mobile-menu-links a:hover{color:var(--gold);border-left-color:var(--orange)}
-                        .mobile-menu-links a:hover::before{width:100%}
-                        .mobile-submenu{padding-left:1rem;max-height:0;overflow:hidden;transition:max-height .3s}
-                        .mobile-submenu.active{max-height:300px}
-                        .mobile-submenu a{font-size:.95rem;padding:.8rem 1rem}
-                        .mobile-dropdown-toggle{display:flex;align-items:center;justify-content:space-between;cursor:pointer;font-size:1.1rem;text-transform:uppercase;letter-spacing:.15em;font-weight:600;font-family:Montserrat,sans-serif;color:var(--white);padding:1rem;border-left:3px solid transparent;transition:all .3s}
-                        .mobile-dropdown-toggle::after{content:'▼';font-size:.7rem;transition:transform .3s}
-                        .mobile-dropdown-toggle.active::after{transform:rotate(180deg)}
-                        .mobile-dropdown-toggle:hover{color:var(--gold);border-left-color:var(--orange)}
-                        .mobile-menu-contacts{border-top:1px solid rgba(74,155,142,.3);padding-top:1.5rem}
-                        .mobile-menu-contacts h3{font-size:.9rem;color:var(--gold);margin-bottom:1rem;letter-spacing:.2em;text-transform:uppercase}
-                        .mobile-menu-contacts p{font-size:.85rem;margin-bottom:.5rem;color:var(--white-dim)}
-                        .mobile-menu-contacts a{color:var(--white);text-decoration:none;transition:color .3s}
-
-                        /* PROGRESS BAR CENTRALE OTTIMIZZATA */
-                        .progress-bar-container{position:fixed;top:0;left:50%;transform:translateX(-50%);width:4px;height:100vh;z-index:999;pointer-events:none;opacity:0;transition:opacity .8s ease}
-                        .progress-bar-container.visible{opacity:1}
-                        .progress-bar{position:absolute;top:0;left:0;width:100%;height:0;background:linear-gradient(180deg,rgba(255,107,53,0) 0%,rgba(255,107,53,.9) 15%,rgba(212,175,55,.95) 50%,rgba(74,155,142,.9) 85%,rgba(74,155,142,0) 100%);box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5);transition:height .1s linear;filter:blur(.8px);will-change:height;animation:progressGlow 3s ease-in-out infinite}
-                        @keyframes progressGlow{0%,100%{box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5)}50%{box-shadow:0 0 40px rgba(255,215,0,1),0 0 70px rgba(255,140,0,.9),0 0 100px rgba(255,107,53,.7)}}
-                        .progress-bar::before{content:'';position:absolute;bottom:-8px;left:50%;transform:translateX(-50%);width:16px;height:16px;background:radial-gradient(circle,var(--gold),transparent);border-radius:50%;box-shadow:0 0 20px var(--gold),0 0 30px var(--orange);animation:dotPulse 2s ease-in-out infinite}
-                        @keyframes dotPulse{0%,100%{transform:translateX(-50%) scale(1);opacity:1}50%{transform:translateX(-50%) scale(1.5);opacity:.8}}
-                        .progress-bar.section-pulse{animation:sectionPulse .8s ease-out,progressGlow 3s ease-in-out infinite}
-                        @keyframes sectionPulse{0%{box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5);width:4px;filter:blur(.8px)}20%{box-shadow:0 0 50px rgba(255,215,0,1),0 0 90px rgba(255,140,0,1),0 0 130px rgba(255,107,53,.9);width:8px;filter:blur(1.5px)}60%{box-shadow:0 0 50px rgba(255,215,0,1),0 0 90px rgba(255,140,0,1),0 0 130px rgba(255,107,53,.9);width:8px;filter:blur(1.5px)}100%{box-shadow:0 0 25px rgba(212,175,55,.9),0 0 40px rgba(255,107,53,.5);width:4px;filter:blur(.8px)}}
-
-                        .scroll-indicator{position:absolute;bottom:2rem;left:50%;transform:translateX(-50%);display:flex;flex-direction:column;align-items:center;gap:.5rem;opacity:0;transition:opacity .5s;z-index:30;cursor:pointer}
-                        section.visible .scroll-indicator{opacity:.8}
-                        .scroll-indicator:hover{opacity:1}
-                        .scroll-text{font-size:.7rem;letter-spacing:.3em;color:var(--gold);text-transform:uppercase;font-weight:600;text-shadow:0 0 10px rgba(212,175,55,.6);animation:textFloat 3s ease-in-out infinite}
-                        @keyframes textFloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-5px)}}
-                        .scroll-icon{width:24px;height:40px;border:2px solid var(--gold);border-radius:15px;position:relative;transition:all .3s;box-shadow:0 0 10px rgba(212,175,55,.4)}
-                        .scroll-icon::before{content:'';position:absolute;top:6px;left:50%;transform:translateX(-50%);width:3px;height:6px;background:var(--gold);border-radius:3px;animation:scrollDot 2s ease-in-out infinite;box-shadow:0 0 5px var(--gold)}
-                        @keyframes scrollDot{0%{top:6px;opacity:1}100%{top:26px;opacity:0}}
-
-                        section{min-height:100vh;display:flex;align-items:center;justify-content:flex-start;position:relative;padding:6rem var(--left) 6rem 5%;opacity:0;transform:translateY(60px);transition:opacity 1s,transform 1s;z-index:20}
-                        section.visible{opacity:1;transform:translateY(0)}
-                        .section-content{max-width:900px;width:100%;text-align:left;z-index:20;position:relative;padding:3rem;border-radius:15px}
-                        .section-bg{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:70%;max-width:900px;height:80%;z-index:-1;background-size:cover;background-position:center;opacity:0;filter:brightness(.55)contrast(1.3)saturate(1.4)sepia(.3);transition:opacity 2s,filter 2s;-webkit-mask-image:linear-gradient(to bottom,rgba(0,0,0,.8)0%,rgba(0,0,0,.5)60%,transparent 100%);mask-image:linear-gradient(to bottom,rgba(0,0,0,.8)0%,rgba(0,0,0,.5)60%,transparent 100%);mix-blend-mode:luminosity;border-radius:20px}
-                        #hero .section-bg{background-image:url('https://images.unsplash.com/photo-1518709268801-4f5d3f4c5c3d?w=1200&q=80&auto=format&fit=crop')}
-                        #about .section-bg{background-image:url('https://images.unsplash.com/photo-1559136555-9303baea8ebd?w=1200&q=80&auto=format&fit=crop')}
-                        #mission .section-bg{background-image:url('https://images.unsplash.com/photo-1552664730-d307ca884978?w=1200&q=80&auto=format&fit=crop')}
-                        #vision .section-bg{background-image:url('https://images.unsplash.com/photo-1497366754035-f200968a6e72?w=1200&q=80&auto=format&fit=crop')}
-                        #values .section-bg{background-image:url('https://images.unsplash.com/photo-1553484771-371a605b060b?w=1200&q=80&auto=format&fit=crop')}
-                        #services .section-bg{background-image:url('https://images.unsplash.com/photo-1559028012-481c04fa702d?w=1200&q=80&auto=format&fit=crop')}
-                        #team .section-bg{background-image:url('https://images.unsplash.com/photo-1556761175-5973dc0f32e7?w=1200&q=80&auto=format&fit=crop')}
-                        #testimonials .section-bg{background-image:url('https://images.unsplash.com/photo-1551836026-d5c88ac5d69a?w=1200&q=80&auto=format&fit=crop')}
-                        #blog .section-bg{background-image:url('https://images.unsplash.com/photo-1586953208448-b95a79798f07?w=1200&q=80&auto=format&fit=crop')}
-                        #contact .section-bg{background-image:url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=1200&q=80&auto=format&fit=crop')}
-                        section.visible .section-bg{opacity:1;filter:brightness(.55)contrast(1.4)saturate(1.5)sepia(.3)}
-                        .section-subtitle{font-size:.9rem;letter-spacing:.4em;color:var(--gold);margin-bottom:1.5rem;font-weight:600;text-transform:uppercase;opacity:0;transition:opacity 1s .2s;text-shadow:0 0 15px rgba(255,107,53,.5);animation:textFloat 4s ease-in-out infinite}
-                        section.visible .section-subtitle{opacity:1}
-                        .section-title{font-size:clamp(2.5rem,6vw,4.5rem);font-weight:900;margin-bottom:2rem;line-height:1;background:linear-gradient(135deg,var(--white),var(--gold-light),var(--orange),var(--teal));background-size:200% 100%;-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:-.02em;opacity:0;transition:opacity 1s .4s;position:relative;filter:drop-shadow(0 2px 15px rgba(255,107,53,.4));animation:titleFloat 5s ease-in-out infinite}
-                        @keyframes titleFloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-8px)}}
-                        section.visible .section-title{opacity:1}
-                        .section-text{font-size:1.15rem;line-height:1.9;color:var(--white);font-weight:400;margin-bottom:2.5rem;opacity:0;transition:opacity 1s .6s;text-shadow:0 1px 3px rgba(0,0,0,.6);animation:textFloat 6s ease-in-out infinite}
-                        section.visible .section-text{opacity:1}
-                        .hero-title{font-size:clamp(3rem,8vw,6.5rem);font-weight:900;line-height:.95;margin-bottom:2rem;background:linear-gradient(135deg,#ffd700,#ff6b35,#4a9b8e,var(--white),var(--gold));background-size:300% 100%;-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:-.03em;filter:drop-shadow(0 3px 20px rgba(255,107,53,.6));animation:heroFloat 4s ease-in-out infinite}
-                        @keyframes heroFloat{0%,100%{transform:translateY(0)}50%{transform:translateY(-12px)}}
-                        .cta-button{display:inline-block;padding:1.2rem 3rem;background:rgba(10,14,20,.9);border:2px solid var(--gold);color:var(--gold);text-decoration:none;text-transform:uppercase;letter-spacing:.25em;font-size:.85rem;font-weight:700;transition:all .5s;position:relative;overflow:hidden;border-radius:4px;box-shadow:0 0 20px rgba(212,175,55,.3),inset 0 0 10px rgba(255,107,53,.1)}
-                        .cta-button::before{content:'';position:absolute;top:50%;left:50%;width:0;height:0;background:linear-gradient(135deg,var(--orange),var(--gold),var(--teal));transition:all .5s;transform:translate(-50%,-50%);border-radius:50%;z-index:-1}
-                        .cta-button:hover{color:#000;transform:translateY(-3px);box-shadow:0 10px 30px rgba(255,107,53,.5)}
-                        .cta-button:hover::before{width:500px;height:500px}
-                        .services-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(280px,1fr));gap:2rem;margin-top:3rem}
-
-                        /* OVERLAY PER EFFETTO OSCURAMENTO */
-                        .card-overlay{position:fixed;inset:0;background:rgba(0,0,0,.75);backdrop-filter:blur(3px);opacity:0;visibility:hidden;transition:opacity .4s,visibility .4s;z-index:998;pointer-events:none}
-                        .card-overlay.active{opacity:1;visibility:visible;pointer-events:auto}
-
-                        /* VAULT CARDS OTTIMIZZATE */
-                        .vault-card,.service-card,.team-card,.testimonial-card,.blog-card{position:relative;will-change:transform;transition:transform .3s,opacity .3s,box-shadow .3s}
-                        .cards-dimmed .vault-card:not(.flipped),.cards-dimmed .service-card:not(.flipped),.cards-dimmed .team-card:not(.flipped),.cards-dimmed .testimonial-card:not(.flipped),.cards-dimmed .blog-card:not(.flipped){opacity:.4;transform:scale(.98)}
-                        .vault-card.flipped,.service-card.flipped,.team-card.flipped,.testimonial-card.flipped,.blog-card.flipped{z-index:999;transform:scale(1.08)!important;opacity:1!important;box-shadow:0 25px 80px rgba(0,0,0,.9),0 0 60px rgba(255,107,53,.6)!important}
-
-                        .service-card{background:linear-gradient(135deg,rgba(13,27,42,.95),rgba(10,14,20,.98));border:2px solid rgba(74,155,142,.25);border-radius:12px;padding:2.5rem 1.5rem;text-align:center;cursor:pointer;overflow:hidden;box-shadow:0 5px 20px rgba(0,0,0,.5),inset 0 1px 0 rgba(74,155,142,.1),0 0 30px rgba(212,175,55,.15);perspective:1000px;min-height:420px}
-                        .service-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d}
-                        .service-card.flipped .service-card-inner{transform:rotateY(180deg)}
-                        .service-front,.service-back{position:absolute;width:100%;height:100%;backface-visibility:hidden;display:flex;flex-direction:column;align-items:center;justify-content:center}
-                        .service-back{transform:rotateY(180deg);padding:1.5rem}
-                        .service-card::before{content:'';position:absolute;inset:0;background-size:cover;background-position:center;opacity:0;transition:opacity .4s;z-index:0;border-radius:12px}
-                        .service-card:nth-child(1)::before{background-image:url('https://images.unsplash.com/photo-1561070791-2526d30994b5?w=600&q=80')}
-                        .service-card:nth-child(2)::before{background-image:url('https://images.unsplash.com/photo-1455390582262-044cdead277a?w=600&q=80')}
-                        .service-card:nth-child(3)::before{background-image:url('https://images.unsplash.com/photo-1561070791-36c11767b26a?w=600&q=80')}
-                        .service-card:nth-child(4)::before{background-image:url('https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=600&q=80')}
-                        .service-card:nth-child(5)::before{background-image:url('https://images.unsplash.com/photo-1432888498266-38ffec3eaf0a?w=600&q=80')}
-                        .service-card:nth-child(6)::before{background-image:url('https://images.unsplash.com/photo-1611162617474-5b21e879e113?w=600&q=80')}
-                        .service-card::after{content:'';position:absolute;inset:0;background:rgba(10,14,20,.85);z-index:1;transition:background .4s;border-radius:12px}
-                        .service-card.flipped::before{opacity:1}
-                        .service-card.flipped::after{background:rgba(10,14,20,.5)}
-                        .service-icon{font-size:3.5rem;margin-bottom:1.5rem;display:block;position:relative;z-index:2;filter:drop-shadow(0 0 10px rgba(212,175,55,.5))}
-                        .service-card h3{font-size:1.3rem;font-weight:800;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:1rem;text-transform:uppercase;letter-spacing:.1em;position:relative;z-index:2}
-                        .service-card p{font-size:.95rem;line-height:1.6;color:var(--white);position:relative;z-index:2;text-shadow:0 1px 2px rgba(0,0,0,.5)}
-                        .service-back p{font-size:.9rem;line-height:1.7;margin-bottom:1.5rem}
-                        .service-cta{display:inline-block;padding:.8rem 1.8rem;background:rgba(212,175,55,.1);border:2px solid var(--gold);color:var(--gold);text-decoration:none;font-size:.75rem;text-transform:uppercase;letter-spacing:.2em;font-weight:700;border-radius:4px;position:relative;z-index:2;transition:all .3s;overflow:hidden}
-                        .service-cta::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--orange),var(--gold));opacity:0;transition:opacity .3s;z-index:-1}
-                        .service-cta:hover{color:#000}
-                        .service-cta:hover::before{opacity:1}
-
-                        .carousel-nav{display:flex;justify-content:flex-start;gap:1rem;margin-top:2rem}
-                        .carousel-arrow{background:linear-gradient(135deg,rgba(13,27,42,.95),rgba(10,14,20,.9));border:2px solid var(--gold);color:var(--gold);width:50px;height:50px;border-radius:50%;display:flex;align-items:center;justify-content:center;cursor:pointer;transition:all .4s;font-size:1.5rem;font-weight:700;user-select:none;position:relative;overflow:hidden;box-shadow:0 4px 15px rgba(0,0,0,.4),0 0 15px rgba(212,175,55,.2)}
-                        .carousel-arrow::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--orange),var(--gold),var(--teal));opacity:0;transition:opacity .3s}
-                        .carousel-arrow:hover{background:var(--gold);color:#000;transform:scale(1.2);box-shadow:0 6px 20px rgba(255,107,53,.5)}
-                        .carousel-arrow:hover::before{opacity:1}
-                        .slider-container{max-width:100%;overflow:hidden;position:relative}
-                        .slider-wrapper{display:flex;gap:2rem;padding:2rem 0;overflow-x:auto;scroll-snap-type:x mandatory;scroll-behavior:smooth;scrollbar-width:none;-webkit-overflow-scrolling:touch}
-                        .slider-wrapper::-webkit-scrollbar{display:none}
-                        .vault-card,.testimonial-card,.blog-card,.team-card{flex-shrink:0;scroll-snap-align:center}
-                        .vault-card{min-width:320px;max-width:320px;height:420px;perspective:1000px;cursor:pointer}
-                        .vault-door{width:100%;height:100%;position:relative;transform-style:preserve-3d;transition:transform .8s}
-                        .vault-card.flipped .vault-door{transform:rotateY(180deg)}
-                        .vault-front,.vault-back{position:absolute;width:100%;height:100%;backface-visibility:hidden;border-radius:10px;display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem 1.5rem;box-shadow:0 10px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15)}
-                        .vault-front{background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.4)}
-                        .vault-back{background:linear-gradient(135deg,rgba(10,14,20,1),rgba(13,27,42,1));border:2px solid var(--orange);transform:rotateY(180deg)}
-                        .vault-lock{width:80px;height:80px;border:4px solid var(--gold);border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:2.5rem;margin-bottom:1.5rem;background:radial-gradient(circle,rgba(255,107,53,.3),rgba(0,0,0,.9));box-shadow:0 0 30px rgba(212,175,55,.6)}
-                        .vault-front h3,.vault-back h3{font-size:1.3rem;font-weight:800;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:.2em;text-align:center}
-                        .vault-hint{margin-top:1rem;font-size:.75rem;color:var(--white-dim);letter-spacing:.2em}
-                        .vault-icon{font-size:3rem;margin-bottom:1.5rem;filter:drop-shadow(0 0 15px rgba(255,107,53,.7))}
-                        .vault-back p{font-size:.95rem;line-height:1.7;color:var(--white);text-align:center;margin-bottom:1rem}
-                        .vault-cta{display:inline-block;padding:.7rem 1.5rem;background:rgba(212,175,55,.1);border:1px solid var(--gold);color:var(--gold);text-decoration:none;font-size:.75rem;text-transform:uppercase;letter-spacing:.2em;font-weight:700;border-radius:4px;transition:all .3s;margin-top:1rem}
-                        .vault-cta:hover{background:var(--gold);color:#000}
-
-                        .team-card{min-width:340px;max-width:340px;background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.3);border-radius:12px;overflow:hidden;box-shadow:0 15px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15);perspective:1000px;min-height:500px;cursor:pointer}
-                        .team-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d}
-                        .team-card.flipped .team-card-inner{transform:rotateY(180deg)}
-                        .team-front,.team-back{position:absolute;width:100%;height:100%;backface-visibility:hidden}
-                        .team-back{transform:rotateY(180deg);background:linear-gradient(135deg,rgba(10,14,20,1),rgba(13,27,42,1));border:2px solid var(--orange);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem;text-align:center}
-                        .team-photo{width:100%;height:280px;background-size:cover;background-position:center;position:relative;filter:brightness(1.05)contrast(1.1)}
-                        .team-card:nth-child(1) .team-photo{background-image:url('https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&h=500&fit=crop&crop=faces')}
-                        .team-card:nth-child(2) .team-photo{background-image:url('https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&h=500&fit=crop&crop=faces')}
-                        .team-card:nth-child(3) .team-photo{background-image:url('https://images.unsplash.com/photo-1573496359142-b8d87734a5a2?w=400&h=500&fit=crop&crop=faces')}
-                        .team-card:nth-child(4) .team-photo{background-image:url('https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?w=400&h=500&fit=crop&crop=faces')}
-                        .team-card:nth-child(5) .team-photo{background-image:url('https://images.unsplash.com/photo-1580489944761-15a19d654956?w=400&h=500&fit=crop&crop=faces')}
-                        .team-info{padding:1.5rem}
-                        .team-name{font-size:1.2rem;font-weight:800;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;margin-bottom:.5rem}
-                        .team-role{color:var(--gold);font-size:.85rem;font-weight:600;letter-spacing:.15em;text-transform:uppercase;margin-bottom:.8rem}
-                        .team-bio{font-size:.85rem;line-height:1.6;color:var(--white-dim);margin-bottom:1rem}
-                        .team-social{display:flex;gap:.8rem;justify-content:center}
-                        .team-social a{width:32px;height:32px;display:flex;align-items:center;justify-content:center;border-radius:50%;background:rgba(212,175,55,.1);border:1px solid var(--gold);transition:all .3s}
-                        .team-social a:hover{background:var(--gold);transform:scale(1.1)}
-                        .team-social svg{width:16px;height:16px;fill:var(--gold);transition:fill .3s}
-                        .team-social a:hover svg{fill:#000}
-                        .team-join{text-align:left;margin-top:2rem}
-                        .team-join a{display:inline-block;padding:1rem 2rem;background:rgba(10,14,20,.9);border:2px solid var(--gold);color:var(--gold);text-decoration:none;text-transform:uppercase;letter-spacing:.2em;font-size:.85rem;font-weight:700;border-radius:6px;transition:all .4s;box-shadow:0 0 15px rgba(212,175,55,.3)}
-                        .team-join a:hover{background:linear-gradient(135deg,var(--orange),var(--gold));color:#000;transform:translateY(-2px);box-shadow:0 10px 25px rgba(255,107,53,.5)}
-
-                        .testimonial-card{min-width:300px;max-width:300px;padding:2.5rem 2rem;background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.3);border-radius:15px;display:flex;flex-direction:column;align-items:center;box-shadow:0 15px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15);min-height:420px;overflow:hidden;perspective:1000px;cursor:pointer}
-                        .testimonial-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d;display:flex;flex-direction:column;align-items:center;justify-content:center}
-                        .testimonial-card.flipped .testimonial-card-inner{transform:rotateY(180deg)}
-                        .testimonial-front,.testimonial-back{position:absolute;width:100%;height:100%;backface-visibility:hidden;display:flex;flex-direction:column;align-items:center;justify-content:center}
-                        .testimonial-back{transform:rotateY(180deg);padding:1.5rem}
-                        .testimonial-card::before{content:'';position:absolute;top:0;left:0;right:0;height:3px;background:linear-gradient(90deg,transparent,var(--orange),var(--gold),var(--teal),transparent);opacity:.7;z-index:1}
-                        .testimonial-card::after{content:'"';position:absolute;top:1rem;right:1.5rem;font-size:6rem;color:rgba(255,107,53,.15);font-family:Georgia,serif;line-height:1;z-index:0}
-                        .testimonial-image{width:70px;height:70px;border-radius:50%;border:3px solid var(--gold);margin-bottom:1.5rem;background-size:cover;background-position:center;box-shadow:0 0 20px rgba(212,175,55,.5);position:relative;z-index:2}
-                        .testimonial-card:nth-child(1) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=12')}
-                        .testimonial-card:nth-child(2) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=5')}
-                        .testimonial-card:nth-child(3) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=33')}
-                        .testimonial-card:nth-child(4) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=9')}
-                        .testimonial-card:nth-child(5) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=13')}
-                        .testimonial-card:nth-child(6) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=14')}
-                        .testimonial-card:nth-child(7) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=20')}
-                        .testimonial-card:nth-child(8) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=68')}
-                        .testimonial-card:nth-child(9) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=27')}
-                        .testimonial-card:nth-child(10) .testimonial-image{background-image:url('https://i.pravatar.cc/150?img=32')}
-                        .testimonial-text{font-size:1rem;line-height:1.7;color:var(--white);font-style:italic;margin-bottom:1.5rem;text-align:center;position:relative;z-index:2}
-                        .testimonial-author{font-size:1rem;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;font-weight:700;margin-bottom:.3rem;letter-spacing:.05em;position:relative;z-index:2}
-                        .testimonial-company{font-size:.85rem;color:var(--white-dim);letter-spacing:.1em;position:relative;z-index:2}
-
-                        .blog-card{min-width:340px;max-width:340px;background:linear-gradient(135deg,rgba(13,27,42,.98),rgba(10,14,20,1));border:2px solid rgba(74,155,142,.3);border-radius:12px;overflow:hidden;box-shadow:0 15px 50px rgba(0,0,0,.7),0 0 20px rgba(255,107,53,.15);min-height:480px;perspective:1000px;cursor:pointer}
-                        .blog-card-inner{position:relative;width:100%;height:100%;transition:transform .8s;transform-style:preserve-3d}
-                        .blog-card.flipped .blog-card-inner{transform:rotateY(180deg)}
-                        .blog-front,.blog-back{position:absolute;width:100%;height:100%;backface-visibility:hidden}
-                        .blog-back{transform:rotateY(180deg);background:linear-gradient(135deg,rgba(10,14,20,1),rgba(13,27,42,1));border:2px solid var(--orange);display:flex;flex-direction:column;align-items:center;justify-content:center;padding:2rem;text-align:center}
-                        .blog-image{width:100%;height:200px;display:flex;align-items:center;justify-content:center;position:relative;overflow:hidden;background-size:cover;background-position:center}
-                        .blog-card:nth-child(1) .blog-image{background-image:url('https://images.unsplash.com/photo-1499750310107-5fef28a66643?w=600&q=80')}
-                        .blog-card:nth-child(2) .blog-image{background-image:url('https://images.unsplash.com/photo-1558655146-9f40138edfeb?w=600&q=80')}
-                        .blog-card:nth-child(3) .blog-image{background-image:url('https://images.unsplash.com/photo-1460925895917-afdab827c52f?w=600&q=80')}
-                        .blog-card:nth-child(4) .blog-image{background-image:url('https://images.unsplash.com/photo-1556155092-490a1ba16284?w=600&q=80')}
-                        .blog-card:nth-child(5) .blog-image{background-image:url('https://images.unsplash.com/photo-1552664730-d307ca884978?w=600&q=80')}
-                        .blog-card:nth-child(6) .blog-image{background-image:url('https://images.unsplash.com/photo-1486312338219-ce68d2c6f44d?w=600&q=80')}
-                        .blog-card:nth-child(7) .blog-image{background-image:url('https://images.unsplash.com/photo-1533750516457-a7f992034fec?w=600&q=80')}
-                        .blog-card:nth-child(8) .blog-image{background-image:url('https://images.unsplash.com/photo-1551288049-bebda4e38f71?w=600&q=80')}
-                        .blog-card:nth-child(9) .blog-image{background-image:url('https://images.unsplash.com/photo-1542744173-8e7e53415bb0?w=600&q=80')}
-                        .blog-card:nth-child(10) .blog-image{background-image:url('https://images.unsplash.com/photo-1519389950473-47ba0277781c?w=600&q=80')}
-                        .blog-image::before{content:'';position:absolute;inset:0;background:linear-gradient(to bottom,rgba(10,14,20,.2),rgba(10,14,20,.6))}
-                        .blog-content{padding:2rem 1.5rem}
-                        .blog-date{font-size:.75rem;background:linear-gradient(90deg,#ff6b35,#d4af37,#4a9b8e);-webkit-background-clip:text;-webkit-text-fill-color:transparent;text-transform:uppercase;letter-spacing:.25em;margin-bottom:.8rem;font-weight:700}
-                        .blog-title{font-size:1.3rem;color:var(--white);margin-bottom:.6rem;font-weight:800;line-height:1.3}
-                        .blog-subtitle{font-size:.9rem;color:var(--gold);margin-bottom:.8rem;font-weight:600}
-                        .blog-excerpt{font-size:.9rem;color:var(--white-dim);line-height:1.6}
-
-                        .contact-form{max-width:700px;width:100%;margin:3rem 0 0}
-                        .form-row{display:grid;grid-template-columns:1fr 1fr;gap:1.5rem;margin-bottom:1.5rem}
-                        .form-group{width:100%}
-                        .form-group.full-width{grid-column:1/-1}
-                        .form-input,.form-select,.form-textarea{width:100%;padding:1.2rem;background:rgba(13,27,42,.9);border:2px solid rgba(74,155,142,.3);color:var(--white);font-family:inherit;font-size:.95rem;transition:all .4s;border-radius:6px;box-shadow:inset 0 2px 5px rgba(0,0,0,.4)}
-                        .form-input:focus,.form-select:focus,.form-textarea:focus{outline:0;border-color:var(--orange);background:rgba(13,27,42,.95);box-shadow:0 0 20px rgba(255,107,53,.3)}
-                        .form-textarea{resize:vertical;min-height:140px}
-                        .form-submit{width:100%;padding:1.2rem;background:rgba(10,14,20,.9);border:2px solid var(--gold);color:var(--gold);text-transform:uppercase;letter-spacing:.25em;font-size:.9rem;font-weight:700;cursor:pointer;transition:all .5s;position:relative;overflow:hidden;border-radius:6px;box-shadow:0 0 20px rgba(212,175,55,.3)}
-                        .form-submit::before{content:'';position:absolute;top:50%;left:50%;width:0;height:0;background:linear-gradient(135deg,var(--orange),var(--gold),var(--teal));transition:all .5s;transform:translate(-50%,-50%);border-radius:50%;z-index:-1}
-                        .form-submit:hover{color:#000;transform:translateY(-3px);box-shadow:0 10px 30px rgba(255,107,53,.5)}
-                        .form-submit:hover::before{width:700px;height:700px}
-
-                        footer{padding:4rem 5%;border-top:1px solid rgba(74,155,142,.3);margin-top:8rem;position:relative;z-index:20;background:rgba(10,14,20,.5)}
-                        .sub-footer{display:grid;grid-template-columns:repeat(4,1fr);gap:3rem;margin-bottom:3rem}
-                        .footer-section h3{font-size:1rem;color:var(--gold);margin-bottom:1.5rem;text-transform:uppercase;letter-spacing:.2em;font-weight:800}
-                        .footer-bio{color:var(--white-dim);line-height:1.7;font-size:.9rem}
-                        .footer-menu{list-style:none}
-                        .footer-menu li{margin-bottom:.8rem}
-                        .footer-menu a{color:var(--white-dim);text-decoration:none;font-size:.9rem;transition:color .3s}
-                        .footer-menu a:hover{color:var(--gold)}
-                        .footer-contact{color:var(--white-dim);font-size:.9rem;line-height:1.8}
-                        .footer-contact a{color:var(--white);text-decoration:none;transition:color .3s}
-                        .footer-contact a:hover{color:var(--gold)}
-                        .newsletter-form{display:flex;gap:.5rem}
-                        .newsletter-input{flex:1;padding:.8rem;background:rgba(13,27,42,.9);border:2px solid rgba(74,155,142,.3);color:var(--white);font-family:inherit;font-size:.85rem;border-radius:4px}
-                        .newsletter-btn{padding:.8rem 1.5rem;background:linear-gradient(135deg,var(--orange),var(--gold));color:#000;border:none;font-weight:700;text-transform:uppercase;letter-spacing:.1em;font-size:.75rem;border-radius:4px;cursor:pointer;transition:all .3s;position:relative;overflow:hidden}
-                        .newsletter-btn::before{content:'';position:absolute;inset:0;background:linear-gradient(135deg,var(--orange),var(--gold));opacity:.6;filter:blur(15px);z-index:-1;animation:ctaPulse 2s ease-in-out infinite}
-                        .newsletter-btn:hover{transform:translateY(-2px);box-shadow:0 5px 15px rgba(255,107,53,.5)}
-                        .footer-bottom{display:flex;justify-content:space-between;align-items:center;padding-top:2rem;border-top:1px solid rgba(74,155,142,.2);flex-wrap:wrap;gap:1rem}
-                        .footer-text{font-size:.9rem;color:var(--white-dim);letter-spacing:.1em}
-                        .footer-links{display:flex;gap:2rem}
-                        .footer-links a{color:var(--white-dim);text-decoration:none;font-size:.85rem;transition:color .3s}
-                        .footer-links a:hover{color:var(--gold)}
-
-                        #tower3DContainer{position:fixed;top:0;right:0;width:clamp(320px,38vw,600px);height:100vh;z-index:0;pointer-events:none;background:transparent;border:none;box-shadow:none}
-                        #tower3DContainer canvas{display:block;width:100%!important;height:100%!important}
-                        #particleCanvas{position:fixed;top:0;left:0;width:100%;height:100%;pointer-events:none;z-index:1;opacity:.7}
-                        .light-glow{position:fixed;width:600px;height:600px;border-radius:50%;background:radial-gradient(circle,rgba(212,175,55,.4),rgba(255,107,53,.2),transparent);filter:blur(100px);pointer-events:none;z-index:2;opacity:0;transition:opacity 1s}
-                        .light-glow.active{opacity:1}
-
-                        @media(max-width:1024px){
-                            .nav-menu{display:none}
-                            .vault-card,.testimonial-card,.blog-card,.team-card{min-width:280px;max-width:280px}
-                            .vault-card{height:380px}
-                            #tower3DContainer{opacity:.4!important;width:clamp(280px,50vw,400px)}
-                            .sub-footer{grid-template-columns:1fr 1fr}
-                            .cursor,.cursor-follower{display:none}
-                        }
-                        @media(max-width:768px){
-                            nav{padding:1rem 5%}
-                            section{padding:5rem 5%}
-                            .section-content{padding:2.5rem 1.5rem}
-                            .form-row{grid-template-columns:1fr}
-                            .vault-card,.testimonial-card,.blog-card,.team-card{min-width:260px;max-width:260px}
-                            .vault-card{height:360px}
-                            .services-grid{grid-template-columns:1fr}
-                            .sub-footer{grid-template-columns:1fr}
-                            .footer-bottom{flex-direction:column;text-align:center}
-                            .hero-title{font-size:clamp(2.5rem,7vw,5rem)}
-                        }
-                        @media(max-width:480px){
-                            .section-content{padding:2rem 1rem}
-                            .vault-card,.testimonial-card,.blog-card,.team-card{min-width:240px;max-width:240px}
-                            .mobile-menu{max-width:100%}
-                        }
-                    </style>
-                    </head>
-                        <body>
-
-                        <div class="loader" id="loader">
-                            <svg class="loader-tower" viewBox="0 0 180 260" xmlns="http://www.w3.org/2000/svg">
-                                <defs>
-                                    <linearGradient id="g1" x1="0%" y1="0%" x2="0%" y2="100%">
-                                        <stop offset="0%" style="stop-color:#ffd700;stop-opacity:1"/>
-                                        <stop offset="100%" style="stop-color:#ff6b35;stop-opacity:1"/>
-                                    </linearGradient>
-                                </defs>
-                                <g fill="none" stroke="url(#g1)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
-                                    <path d="M90 10 L90 26" style="--len:16;animation-delay:0s"/>
-                                    <path d="M78 26 Q90 18 102 26 L102 40 Q90 34 78 40 Z" style="--len:50;animation-delay:.1s"/>
-                                    <path d="M68 40 L112 40 L112 210 L68 210 Z" style="--len:504;animation-delay:.2s"/>
-                                    <path d="M68 60 Q90 54 112 60" style="--len:50;animation-delay:.3s"/>
-                                    <path d="M68 82 Q90 76 112 82" style="--len:50;animation-delay:.4s"/>
-                                    <path d="M68 104 Q90 98 112 104" style="--len:50;animation-delay:.5s"/>
-                                    <path d="M68 126 Q90 120 112 126" style="--len:50;animation-delay:.6s"/>
-                                    <path d="M68 148 Q90 142 112 148" style="--len:50;animation-delay:.7s"/>
-                                    <path d="M68 170 Q90 164 112 170" style="--len:50;animation-delay:.8s"/>
-                                    <path d="M58 210 L122 210 L122 230 L58 230 Z" style="--len:192;animation-delay:.9s"/>
-                                    <path d="M10 240 L10 222 26 222 26 212 42 212 42 240" style="--len:90;animation-delay:1s" opacity="0.6"/>
-                                    <path d="M138 240 L138 218 150 218 150 210 166 210 166 240" style="--len:90;animation-delay:1.1s" opacity="0.6"/>
-                                    <path d="M6 240 L174 240" style="--len:168;animation-delay:1.2s" opacity="0.6"/>
-                                </g>
-                            </svg>
-                            <div class="loader-text" id="loaderText"></div>
-                            <div class="loader-bar-wrap">
-                                <div class="loader-bar" id="loaderBar"></div>
-                            </div>
-                        </div>
-
-                        <div class="vignette"></div>
-                        <div class="progress-bar-container" id="progressBarContainer">
-                            <div class="progress-bar" id="progressBar"></div>
-                        </div>
-                        <div class="cursor"></div>
-                        <div class="cursor-follower"></div>
-                        <div class="card-overlay" id="cardOverlay"></div>
-
-                        <div class="carbon-fiber"></div>
-                        <canvas id="particleCanvas"></canvas>
-                        <div class="light-glow" id="lightGlow1" style="top:20%;left:10%"></div>
-                        <div class="light-glow" id="lightGlow2" style="top:60%;right:10%"></div>
-
-                        <nav id="mainNav">
-                            <div class="nav-logo" onclick="scrollToSection('hero')">DIGITAL TOWER</div>
-                            <ul class="nav-menu">
-                                <li class="nav-dropdown">
-                                    <a href="javascript:void(0)">Chi Siamo</a>
-                                    <ul class="nav-dropdown-menu">
-                                        <li><a href="javascript:void(0)" onclick="scrollToSection('mission')">Missione</a></li>
-                                        <li><a href="javascript:void(0)" onclick="scrollToSection('vision')">Visione</a></li>
-                                        <li><a href="javascript:void(0)" onclick="scrollToSection('values')">Valori</a></li>
-                                    </ul>
-                                </li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('services')">Servizi</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('team')">Team</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('testimonials')">Testimonial</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('blog')">Blog</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('contact')" class="nav-cta">CONSULENZA</a></li>
-                            </ul>
-                            <div class="hamburger" id="hamburger">
-                                <span></span><span></span><span></span>
-                            </div>
-                        </nav>
-
-                        <div class="mobile-menu" id="mobileMenu">
-                            <ul class="mobile-menu-links">
-                                <li>
-                                    <div class="mobile-dropdown-toggle" onclick="toggleMobileSubmenu(this)"><span>Chi Siamo</span></div>
-                                    <ul class="mobile-submenu">
-                                        <li><a href="javascript:void(0)" onclick="scrollToSection('mission');closeMobileMenu()">Missione</a></li>
-                                        <li><a href="javascript:void(0)" onclick="scrollToSection('vision');closeMobileMenu()">Visione</a></li>
-                                        <li><a href="javascript:void(0)" onclick="scrollToSection('values');closeMobileMenu()">Valori</a></li>
-                                    </ul>
-                                </li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('services');closeMobileMenu()">Servizi</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('team');closeMobileMenu()">Team</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('testimonials');closeMobileMenu()">Testimonial</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('blog');closeMobileMenu()">Blog</a></li>
-                                <li><a href="javascript:void(0)" onclick="scrollToSection('contact');closeMobileMenu()" class="nav-cta">CONSULENZA</a></li>
-                            </ul>
-                            <div class="mobile-menu-contacts">
-                                <h3>Contatti</h3>
-                                <p>P.IVA: 10830661210</p>
-                                <p>Tel: <a href="tel:+393770439955">+39 377 043 9955</a></p>
-                                <p>WhatsApp: <a href="https://wa.me/393770439955">+39 377 043 9955</a></p>
-                                <p>Email: <a href="mailto:info@digitaltower.it">info@digitaltower.it</a></p>
-                                <p>Via Francesca Catone 33<br>80014 Giugliano (NA)</p>
-                            </div>
-                        </div>
-
-                        <div id="tower3DContainer"></div>
-
-                        <section class="hero" id="hero">
-                            <div class="section-bg"></div>
-                            <div class="section-content">
-                                <h1 class="hero-title">TRASFORMA LA TUA VISIONE IN SUCCESSO DIGITALE</h1>
-                                <p class="section-text">Qui inizia il viaggio che cambierà per sempre il tuo modo di comunicare. Insieme scaleremo la torre del successo digitale, piano dopo piano, verso risultati straordinari che supereranno ogni tua aspettativa.</p>
-                                <a href="javascript:void(0)" class="cta-button" onclick="scrollToSection('about')">Inizia il Viaggio</a>
-                            </div>
-                            <div class="scroll-indicator" onclick="scrollToSection('about')">
-                                <span class="scroll-text">Scroll</span>
-                                <div class="scroll-icon"></div>
-                            </div>
-                        </section>
-
-                        <section id="about">
-                            <div class="section-bg"></div>
-                            <div class="section-content">
-                                <p class="section-subtitle">La Fondazione</p>
-                                <h2 class="section-title">Chi Siamo</h2>
-                                <p class="section-text">Siamo architetti digitali che costruiscono esperienze indimenticabili. Non creiamo semplicemente siti web o campagne: diamo vita a ecosistemi digitali completi che sfidano la gravità, elevando brand e business verso vette mai raggiunte prima.</p>
-                            </div>
-                            <div class="scroll-indicator" onclick="scrollToSection('mission')">
-                                <span class="scroll-text">Scroll</span>
-                                <div class="scroll-icon"></div>
-                            </div>
-                        </section>
-
-                        <section id="mission">
-                            <div class="section-bg"></div>
-                            <div class="section-content">
-                                <p class="section-subtitle">Il Nostro Scopo</p>
-                                <h2 class="section-title">La Missione</h2>
-                                <p class="section-text">Trasformare ogni idea, anche la più audace, in realtà digitali potenti e misurabili attraverso strategie innovative, creative e data-driven. La nostra missione è rendere ogni cliente protagonista del proprio successo, equipaggiandolo con gli strumenti digitali più avanzati e le strategie più efficaci del mercato.</p>
-                            </div>
-                            <div class="scroll-indicator" onclick="scrollToSection('vision')">
-                                <span class="scroll-text">Scroll</span>
-                                <div class="scroll-icon"></div>
-                            </div>
-                        </section>
-
-                        <section id="vision">
-                            <div class="section-bg"></div>
-                            <div class="section-content">
-                                <p class="section-subtitle">Dove Stiamo Andando</p>
-                                <h2 class="section-title">La Visione</h2>
-                                <p class="section-text">Diventare il punto di riferimento assoluto per l'eccellenza digitale in Italia, costruendo la torre più alta del panorama digital. Una torre dove ogni piano rappresenta un traguardo raggiunto, ogni finestra una storia di successo, ogni mattone una relazione duratura costruita sulla fiducia e sui risultati concreti.</p>
-                            </div>
-                            <div class="scroll-indicator" onclick="scrollToSection('values')">
-                                <span class="scroll-text">Scroll</span>
-                                <div class="scroll-icon"></div>
-                            </div>
-                        </section>
-
-                        <section id="values">
-                            <div class="section-bg"></div>
-                            <div class="section-content" style="max-width:1200px">
-                                <p class="section-subtitle">I Pilastri</p>
-                                <h2 class="section-title">I Nostri Valori</h2>
-                                <p class="section-text">Ogni piano della torre è sostenuto da pilastri incrollabili. Questi valori guidano ogni nostra decisione, ogni progetto, ogni interazione con i clienti.</p>
-                                <div class="slider-container">
-                                    <div class="slider-wrapper" id="valuesSlider">
-                                        <div class="vault-card" onclick="toggleVault(this)">
-                                            <div class="vault-door">
-                                                <div class="vault-front">
-                                                    <div class="vault-lock">🔒</div>
-                                                    <h3>Eccellenza</h3>
-                                                    <p class="vault-hint">CLICCA</p>
-                                                </div>
-                                                <div class="vault-back">
-                                                    <div class="vault-icon">⚡</div>
-                                                    <h3>Eccellenza</h3>
-                                                    <p>Ogni dettaglio conta. Perfezioniamo ossessivamente ogni elemento per creare esperienze digitali indimenticabili che non solo soddisfano, ma superano brillantemente ogni aspettativa dei nostri clienti.</p>
-                                                    <a href="#valori-eccellenza" class="vault-cta">Scopri di più</a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="vault-card" onclick="toggleVault(this)">
-                                            <div class="vault-door">
-                                                <div class="vault-front">
-                                                    <div class="vault-lock">🔒</div>
-                                                    <h3>Innovazione</h3>
-                                                    <p class="vault-hint">CLICCA</p>
-                                                </div>
-                                                <div class="vault-back">
-                                                    <div class="vault-icon">🎯</div>
-                                                    <h3>Innovazione</h3>
-                                                    <p>Non seguiamo le tendenze, le creiamo. Siamo pionieri visionari nel mondo digitale, sempre un passo avanti con soluzioni all'avanguardia che ridefiniscono gli standard del settore.</p>
-                                                    <a href="#valori-innovazione" class="vault-cta">Scopri di più</a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="vault-card" onclick="toggleVault(this)">
-                                            <div class="vault-door">
-                                                <div class="vault-front">
-                                                    <div class="vault-lock">🔒</div>
-                                                    <h3>Partnership</h3>
-                                                    <p class="vault-hint">CLICCA</p>
-                                                </div>
-                                                <div class="vault-back">
-                                                    <div class="vault-icon">🤝</div>
-                                                    <h3>Partnership</h3>
-                                                    <p>Il tuo successo è il nostro successo. Non siamo semplici fornitori, ma partner strategici che crescono insieme a te verso nuove vette con collaborazioni autentiche basate sulla fiducia reciproca.</p>
-                                                    <a href="#valori-partnership" class="vault-cta">Scopri di più</a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                        <div class="vault-card" onclick="toggleVault(this)">
-                                            <div class="vault-door">
-                                                <div class="vault-front">
-                                                    <div class="vault-lock">🔒</div>
-                                                    <h3>Qualità</h3>
-                                                    <p class="vault-hint">CLICCA</p>
-                                                </div>
-                                                <div class="vault-back">
-                                                    <div class="vault-icon">💎</div>
-                                                    <h3>Qualità</h3>
-                                                    <p>Premium è il nostro standard assoluto e innegociabile. Nessun compromesso sulla qualità dei nostri progetti digitali, perché crediamo che l'eccellenza non sia un'opzione, ma una necessità.</p>
-                                                    <a href="#valori-qualita" class="vault-cta">Scopri di più</a>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="carousel-nav">
-                                        <div class="carousel-arrow" onclick="carouselPrev('valuesSlider')">‹</div>
-                                        <div class="carousel-arrow" onclick="carouselNext('valuesSlider')">›</div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="scroll-indicator" onclick="scrollToSection('services')">
-                                <span class="scroll-text">Scroll</span>
-                                <div class="scroll-icon"></div>
-                            </div>
-                        </section>
-
-                        <section id="services">
-                            <div class="section-bg"></div>
-                            <div class="section-content" style="max-width:1200px">
-                                <p class="section-subtitle">Cosa Offriamo</p>
-                                <h2 class="section-title">I Nostri Servizi</h2>
-                                <p class="section-text">Soluzioni digitali complete e integrate per trasformare radicalmente la tua presenza online e generare risultati concreti e misurabili.</p>
-                                <div class="services-grid">
-                                    <div class="service-card" onclick="toggleCard(this)">
-                                        <div class="service-card-inner">
-                                            <div class="service-front">
-                                                <span class="service-icon">🎨</span>
-                                                <h3>Web Design</h3>
-                                                <p>Progettiamo siti web user-centric che uniscono estetica moderna e funzionalità avanzata.</p>
-                                            </div>
-                                            <div class="service-back">
-                                                <h3>Web Design Premium</h3>
-                                                <p>Dalla progettazione UX/UI strategica alla realizzazione tecnica impeccabile, creiamo piattaforme web responsive, performanti e ottimizzate SEO che convertono visitatori in clienti fedeli e appassionati del tuo brand.</p>
-                                                <a href="#servizi-web-design" class="service-cta">Scopri di più</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="service-card" onclick="toggleCard(this)">
-                                        <div class="service-card-inner">
-                                            <div class="service-front">
-                                                <span class="service-icon">✍️</span>
-                                                <h3>Creazione Contenuti</h3>
-                                                <p>Sviluppiamo strategie di content marketing coinvolgenti per ogni piattaforma digitale.</p>
-                                            </div>
-                                            <div class="service-back">
-                                                <h3>Content Marketing</h3>
-                                                <p>Narrazioni autentiche e strategiche per social media, blog aziendali e piattaforme digitali che costruiscono autorità, engagement e connessioni emotive durature con il tuo pubblico target.</p>
-                                                <a href="#servizi-contenuti" class="service-cta">Scopri di più</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="service-card" onclick="toggleCard(this)">
-                                        <div class="service-card-inner">
-                                            <div class="service-front">
-                                                <span class="service-icon">⚡</span>
-                                                <h3>Branding</h3>
-                                                <p>Creiamo identità visive potenti e coerenti che distinguono il tuo brand dalla concorrenza.</p>
-                                            </div>
-                                            <div class="service-back">
-                                                <h3>Brand Identity</h3>
-                                                <p>Dal logo alla brand identity completa, sviluppiamo l'immagine perfetta per il tuo business: memorabile, distintiva e allineata perfettamente ai valori della tua azienda e alle aspettative del tuo target.</p>
-                                                <a href="#servizi-branding" class="service-cta">Scopri di più</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="service-card" onclick="toggleCard(this)">
-                                        <div class="service-card-inner">
-                                            <div class="service-front">
-                                                <span class="service-icon">🚀</span>
-                                                <h3>Advertising</h3>
-                                                <p>Campagne pubblicitarie data-driven su Google Ads, Meta e LinkedIn per massimizzare il ROI.</p>
-                                            </div>
-                                            <div class="service-back">
-                                                <h3>Performance Advertising</h3>
-                                                <p>Strategie di performance marketing avanzate che accelerano esponenzialmente la crescita del tuo business online attraverso campagne ottimizzate al centesimo per generare lead qualificati e conversioni.</p>
-                                                <a href="#servizi-advertising" class="service-cta">Scopri di più</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="service-card" onclick="toggleCard(this)">
-                                        <div class="service-card-inner">
-                                            <div class="service-front">
-                                                <span class="service-icon">📊</span>
-                                                <h3>SEO</h3>
-                                                <p>Ottimizzazione per motori di ricerca con strategie organiche avanzate per traffico qualificato.</p>
-                                            </div>
-                                            <div class="service-back">
-                                                <h3>SEO Strategico</h3>
-                                                <p>Portiamo il tuo sito in prima pagina su Google con tecniche SEO white-hat comprovate, audit tecnici approfonditi, ottimizzazione on-page e off-page, link building di qualità e content strategy mirata.</p>
-                                                <a href="#servizi-seo" class="service-cta">Scopri di più</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="service-card" onclick="toggleCard(this)">
-                                        <div class="service-card-inner">
-                                            <div class="service-front">
-                                                <span class="service-icon">📱</span>
-                                                <h3>Social Media</h3>
-                                                <p>Gestione strategica dei social media per costruire community fedeli e altamente engaged.</p>
-                                            </div>
-                                            <div class="service-back">
-                                                <h3>Social Media Management</h3>
-                                                <p>Da Instagram a LinkedIn, creiamo e gestiamo presenza social che generano risultati misurabili: community management, content creation, influencer marketing e strategie di growth organico e paid.</p>
-                                                <a href="#servizi-social" class="service-cta">Scopri di più</a>
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div>
-                            </div>
-                            <div class="scroll-indicator" onclick="scrollToSection('team')">
-                                <span class="scroll-text">Scroll</span>
-                                <div class="scroll-icon"></div>
-                            </div>
-                        </section>
+    <script src="assets/js/core/loader.js" defer></script>
+    <script src="assets/js/core/tower.js" defer></script>
+    <script src="assets/js/core/particles.js" defer></script>
+    <script src="assets/js/core/cursor.js" defer></script>
+    <script src="assets/js/core/audio.js" defer></script>
+    <script src="assets/js/core/cards.js" defer></script>
+    <script src="assets/js/core/navigation.js" defer></script>
+    <script src="assets/js/core/sections.js" defer></script>
+    <script src="assets/js/core/forms.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- center the fixed tower canvas so the skyscraper renders full width on desktop and mobile breakpoints
- remove blur from the vault overlay, brighten the revealed face, and expand card margins so hover/flip states remain legible
- refresh responsive card spacing on tablets and phones to stop hover scaling from clipping content

## Testing
- for f in assets/js/core/*.js; do echo "Checking $f"; node -e "const fs=require('fs');new Function(fs.readFileSync('$f','utf8'))" || break; done

------
https://chatgpt.com/codex/tasks/task_b_68e38d4fcf5c832cab8376f553be9cab