### PR TITLE
Fix blog archive grid column span for articles

### DIFF
--- a/assets/css/layout/pages.css
+++ b/assets/css/layout/pages.css
@@ -725,6 +725,7 @@ section.visible .page-cta__inner {
 .blog-archive__articles {
   display: grid;
   gap: clamp(1.8rem, 3vw, 2.6rem);
+  grid-column: 1 / span 2;
 }
 
 .blog-archive__header {
@@ -1354,6 +1355,9 @@ section.visible .page-cta__inner {
   }
   .blog-archive__inner {
     grid-template-columns: minmax(0, 1fr);
+  }
+  .blog-archive__articles {
+    grid-column: auto;
   }
   .blog-archive__grid {
     grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));


### PR DESCRIPTION
## Summary
- ensure the blog archive articles section spans the two flexible content columns so the sidebar stays on the right
- reset the article column span on tablet layouts where the archive collapses to a single column

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_b_68e5a0ec2d54832cb2af357c91c39e95